### PR TITLE
Make BGP.tools client IPv6 compatible

### DIFF
--- a/hyperglass/external/bgptools.py
+++ b/hyperglass/external/bgptools.py
@@ -113,6 +113,7 @@ def run_whois_sync(targets: List[str]) -> str:
         err = e
         sock = None
         continue
+      break
 
     if not sock and err:
       raise err

--- a/hyperglass/external/bgptools.py
+++ b/hyperglass/external/bgptools.py
@@ -98,8 +98,25 @@ def run_whois_sync(targets: List[str]) -> str:
 
     # Open the socket to bgp.tools
     log.debug("Opening connection to bgp.tools")
-    sock = socket.socket()
-    sock.connect(("bgp.tools", 43))
+    err = None
+    sock = None
+    for res in socket.getaddrinfo("bpg.tools", 43, socket.AF_UNSPEC, socket.SOCK_STREAM):
+      af, socktype, proto, canonname, sa = res
+      try:
+        sock = socket.socket(af, socktype, proto)
+      except socket.error as e:
+        err = e
+        continue
+      try:
+        sock.connect(("bgp.tools", 43))
+      except socket.error as e:
+        err = e
+        sock = None
+        continue
+
+    if not sock and err:
+      raise err
+
     sock.send(query)
 
     # Read the response

--- a/hyperglass/external/bgptools.py
+++ b/hyperglass/external/bgptools.py
@@ -100,7 +100,7 @@ def run_whois_sync(targets: List[str]) -> str:
     log.debug("Opening connection to bgp.tools")
     err = None
     sock = None
-    for res in socket.getaddrinfo("bpg.tools", 43, socket.AF_UNSPEC, socket.SOCK_STREAM):
+    for res in socket.getaddrinfo("bgp.tools", 43, socket.AF_UNSPEC, socket.SOCK_STREAM):
       af, socktype, proto, canonname, sa = res
       try:
         sock = socket.socket(af, socktype, proto)


### PR DESCRIPTION
# Description

The BGP.tools client used a mode on the python socket library that does not support IPv6 only connections. This PR corrects this.

# Related Issues

N/A

# Motivation and Context

When attempting to run hyperglass on the AS207960 kubernetes cluster which is IPv6 only, in effect, everything broke.

# Tests

Tested as working on the AS207960 k8s cluster, cannot foresee this breaking on any other envs as it is such a simple change.
