### PR TITLE
Replace deprecated base64.{en/de}codestring()

### DIFF
--- a/hyperglass/models/config/logging.py
+++ b/hyperglass/models/config/logging.py
@@ -5,6 +5,7 @@ import base64
 from ast import literal_eval
 from typing import Dict, Union, Optional
 from pathlib import Path
+from sys import version_info
 
 # Third Party
 from pydantic import (
@@ -92,12 +93,17 @@ class Http(HyperglassModelExtra):
             else:
                 dumped["auth"] = self.authentication.basic()
 
-        self._obscured_params = base64.encodestring(str(dumped).encode())
+        if version_info < (3, 8):
+            self._obscured_params = base64.encodestring(str(dumped).encode())
+        else:
+            self._obscured_params = base64.encodebytes(str(dumped).encode())
 
     def decoded(self):
         """Decode connection details."""
-        return literal_eval(base64.decodestring(self._obscured_params).decode())
-
+        if version_info < (3, 8):
+            return literal_eval(base64.decodestring(self._obscured_params).decode())
+        else:
+            return literal_eval(base64.decodebytes(self._obscured_params).decode())
 
 class Logging(HyperglassModel):
     """Validation model for logging configuration."""


### PR DESCRIPTION
base64.decodestring() function has been deprecated since Python 3.1, and removed in Python 3.9
https://docs.python.org/3.8/library/base64.html#base64.decodestring
Gentoo with python3_9

<!-- PLEASE CONSULT CONTRIBUTING.MD PRIOR TO WORKING ON HYPERGLASS -->

<!-- Provide a general summary of your changes in the Title. -->

# Description

<!-- Describe your changes in detail -->

# Related Issues

<!-- Link to any related open issues -->

# Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

# Tests

<!-- Please describe in detail how you tested your changes, including your testing environment (OS, Python version, etc). -->
