### PR TITLE
Httpx upgrade

### DIFF
--- a/docs/docs/adding-devices.mdx
+++ b/docs/docs/adding-devices.mdx
@@ -303,11 +303,11 @@ Here's an example of using this to share two sets of credentials among multiple 
 ```yaml title="devices.yaml"
 my_credentials:
   - credential: &credential1
-    username: madeup1
-    password: gY018mR4gx4sVqc0
+      username: madeup1
+      password: gY018mR4gx4sVqc0
   - credential: &credential2
-    username: madeup2
-    password: 0eMEJ4ZpB6ofkiIF
+      username: madeup2
+      password: 0eMEJ4ZpB6ofkiIF
 
 routers:
   - name: router01

--- a/docs/docs/production.mdx
+++ b/docs/docs/production.mdx
@@ -113,6 +113,9 @@ The `tls` directive will tell Caddy to automatically use Let's Encrypt to genera
 
 The following file can be placed at `/etc/nginx/sites-enabled/hyperglass`. It supports IPv6, and will automatically redirect to HTTPS. The highlighted lines should be replaced with your installation's specific variables.
 
+Replace `server_name` with your own.
+Replace `ssl_certificate` and `ssl_certificate_key` with paths to appropriate files.
+
 ```nginx {4,9,10,17,19} title="NGINX"
 server {
   listen 80;
@@ -159,7 +162,10 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $http_host;
     proxy_redirect off;
+    # for ipv6
     proxy_pass http://[::1]:8001;
+    # for ipv4
+    # proxy_pass http://127.0.0.1:8001;
   }
 
 }

--- a/hyperglass/external/_base.py
+++ b/hyperglass/external/_base.py
@@ -9,7 +9,6 @@ from socket import gaierror
 
 # Third Party
 import httpx
-from httpx import StatusCode
 
 # Project
 from hyperglass.log import log
@@ -244,7 +243,7 @@ class BaseExternal:
             response = await self._asession.request(**request)
 
             if response.status_code not in range(200, 300):
-                status = StatusCode(response.status_code)
+                status = httpx.codes(response.status_code)
                 error = self._parse_response(response)
                 raise self._exception(
                     f'{status.name.replace("_", " ")}: {error}', level="danger"
@@ -300,7 +299,7 @@ class BaseExternal:
             response = self._session.request(**request)
 
             if response.status_code not in range(200, 300):
-                status = StatusCode(response.status_code)
+                status = httpx.codes(response.status_code)
                 error = self._parse_response(response)
                 raise self._exception(
                     f'{status.name.replace("_", " ")}: {error}', level="danger"


### PR DESCRIPTION
httpx 0.18.0 deprecated the httpx.StatusCode class.  This fix allows compatibility with 0.17.1 through at least 0.22.0 vs being stuck on 0.17.1.

# Description

Change over from httpx.StatusCode to httpx.codes.   This is a drop in replacement for how hyperglass uses httpx in this context.

# Related Issues
N/A

# Motivation and Context

I effectively maintain a custom distribution on top of CentOS/Rocky Linux.  My existing httpx version was later that what was required for hyperglass.   The easiest fix was to patch hyperglass so it was compatible with httpx >= 0.17.1 instead of locked into 0.17.1.

# Tests

I ran pylint and flake8 against _base.py and no errors showed up in relation to my changes.  Manual examination of the 0.17.1 source and 0.22.0 source of httpx indicate that StatusCode() from 0.17.1 was just a wrapper around the httpx.codes Enum.

Manual execution of the exception raising code works with a httpx.codes() instance vs a StatuCode() instance.
>>> import httpx
>>> status = httpx.codes(404)
>>> print( f'{status.name.replace("_", " ")}')
NOT FOUND
