### PR TITLE
expanded httpx compatability

### DIFF
--- a/hyperglass/external/_base.py
+++ b/hyperglass/external/_base.py
@@ -9,7 +9,6 @@ from socket import gaierror
 
 # Third Party
 import httpx
-from httpx import StatusCode
 
 # Project
 from hyperglass.log import log
@@ -244,7 +243,7 @@ class BaseExternal:
             response = await self._asession.request(**request)
 
             if response.status_code not in range(200, 300):
-                status = StatusCode(response.status_code)
+                status = httpx.codes(response.status_code)
                 error = self._parse_response(response)
                 raise self._exception(
                     f'{status.name.replace("_", " ")}: {error}', level="danger"
@@ -300,7 +299,7 @@ class BaseExternal:
             response = self._session.request(**request)
 
             if response.status_code not in range(200, 300):
-                status = StatusCode(response.status_code)
+                status = httpx.codes(response.status_code)
                 error = self._parse_response(response)
                 raise self._exception(
                     f'{status.name.replace("_", " ")}: {error}', level="danger"


### PR DESCRIPTION
Sorry, this pull request was originally made against main instead of develop.   

httpx 0.18.0 deprecated the httpx.StatusCode class.  This fix allows compatibility with 0.17.1 through at least 0.22.0 vs being stuck on 0.17.1.

# Description

Change over from httpx.StatusCode to httpx.codes.   This is a drop in replacement for how hyperglass uses httpx in this context.

# Related Issues
N/A

# Motivation and Context

I effectively maintain a custom distribution on top of CentOS/Rocky Linux.  My existing httpx version was later that what was required for hyperglass.   The easiest fix was to patch hyperglass so it was compatible with httpx >= 0.17.1 instead of locked into 0.17.1.

# Tests

I ran pylint and flake8 against _base.py and no errors showed up in relation to my changes.  Manual examination of the 0.17.1 source and 0.22.0 source of httpx indicate that StatusCode() from 0.17.1 was just a wrapper around the httpx.codes Enum.

Manual execution of the exception raising code works with a httpx.codes() instance vs a StatuCode() instance.
>>> import httpx
>>> status = httpx.codes(404)
>>> print( f'{status.name.replace("_", " ")}')
NOT FOUND
