### PR TITLE
Update parameters.mdx to remove log_file parameter from example configuration

### DIFF
--- a/docs/docs/parameters.mdx
+++ b/docs/docs/parameters.mdx
@@ -86,6 +86,5 @@ site_keywords: [hyperglass, looking glass, routing, bgp]
 request_timeout: 30
 listen_address: "127.0.0.1"
 listen_port: 8001
-log_file: /tmp/hyperglass.log
 cors_origins: [lg.example.com, 192.0.2.1]
 ```


### PR DESCRIPTION
log_file is not a valid parameter and should not be included in the docs

# Description

The example configuration includes a reference to a log_file parameter that is not accepted

# Motivation and Context

Documentation should be correct and working; and sadly the documentation as it was did not.
