### PR TITLE
Allow updating Arista and Juniper commands

### DIFF
--- a/hyperglass/models/commands/arista_eos.py
+++ b/hyperglass/models/commands/arista_eos.py
@@ -10,9 +10,9 @@ from .common import CommandSet, CommandGroup
 class _IPv4(CommandSet):
     """Validation model for non-default dual afi commands."""
 
-    bgp_route: StrictStr = "show ip bgp {target}"
-    bgp_aspath: StrictStr = "show ip bgp regexp {target}"
-    bgp_community: StrictStr = "show ip bgp community {target}"
+    bgp_route: StrictStr = "show ip bgp {target} | json"
+    bgp_aspath: StrictStr = "show ip bgp regexp {target} | json"
+    bgp_community: StrictStr = "show ip bgp community {target} | json"
     ping: StrictStr = "ping ip {target} source {source}"
     traceroute: StrictStr = "traceroute ip {target} source {source}"
 
@@ -20,9 +20,9 @@ class _IPv4(CommandSet):
 class _IPv6(CommandSet):
     """Validation model for non-default ipv4 commands."""
 
-    bgp_route: StrictStr = "show ipv6 bgp {target}"
-    bgp_aspath: StrictStr = "show ipv6 bgp regexp {target}"
-    bgp_community: StrictStr = "show ipv6 bgp community {target}"
+    bgp_route: StrictStr = "show ipv6 bgp {target} | json"
+    bgp_aspath: StrictStr = "show ipv6 bgp regexp {target} | json"
+    bgp_community: StrictStr = "show ipv6 bgp community {target} | json"
     ping: StrictStr = "ping ipv6 {target} source {source}"
     traceroute: StrictStr = "traceroute ipv6 {target} source {source}"
 
@@ -30,9 +30,9 @@ class _IPv6(CommandSet):
 class _VPNIPv4(CommandSet):
     """Validation model for non-default ipv6 commands."""
 
-    bgp_route: StrictStr = "show ip bgp {target} vrf {vrf}"
-    bgp_aspath: StrictStr = "show ip bgp regexp {target} vrf {vrf}"
-    bgp_community: StrictStr = "show ip bgp community {target} vrf {vrf}"
+    bgp_route: StrictStr = "show ip bgp {target} vrf {vrf} | json"
+    bgp_aspath: StrictStr = "show ip bgp regexp {target} vrf {vrf} | json"
+    bgp_community: StrictStr = "show ip bgp community {target} vrf {vrf} | json"
     ping: StrictStr = "ping vrf {vrf} ip {target} source {source}"
     traceroute: StrictStr = "traceroute vrf {vrf} ip {target} source {source}"
 
@@ -40,43 +40,11 @@ class _VPNIPv4(CommandSet):
 class _VPNIPv6(CommandSet):
     """Validation model for non-default ipv6 commands."""
 
-    bgp_route: StrictStr = "show ipv6 bgp {target} vrf {vrf}"
-    bgp_aspath: StrictStr = "show ipv6 bgp regexp {target} vrf {vrf}"
-    bgp_community: StrictStr = "show ipv6 bgp community {target} vrf {vrf}"
+    bgp_route: StrictStr = "show ipv6 bgp {target} vrf {vrf} | json"
+    bgp_aspath: StrictStr = "show ipv6 bgp regexp {target} vrf {vrf} | json"
+    bgp_community: StrictStr = "show ipv6 bgp community {target} vrf {vrf} | json"
     ping: StrictStr = "ping vrf {vrf} ipv6 {target} source {source}"
     traceroute: StrictStr = "traceroute vrf {vrf} ipv6 {target} source {source}"
-
-
-_structured = CommandGroup(
-    ipv4_default=CommandSet(
-        bgp_route="show ip bgp {target} | json",
-        bgp_aspath="show ip bgp regexp {target} | json",
-        bgp_community="show ip bgp community {target} | json",
-        ping="ping ip {target} source {source}",
-        traceroute="traceroute ip {target} source {source}",
-    ),
-    ipv6_default=CommandSet(
-        bgp_route="show ipv6 bgp {target} | json",
-        bgp_aspath="show ipv6 bgp regexp {target} | json",
-        bgp_community="show ipv6 bgp community {target} | json",
-        ping="ping ipv6 {target} source {source}",
-        traceroute="traceroute ipv6 {target} source {source}",
-    ),
-    ipv4_vpn=CommandSet(
-        bgp_route="show ip bgp {target} vrf {vrf} | json",
-        bgp_aspath="show ip bgp regexp {target} vrf {vrf} | json",
-        bgp_community="show ip bgp community {target} vrf {vrf} | json",
-        ping="ping vrf {vrf} ip {target} source {source}",
-        traceroute="traceroute vrf {vrf} ip {target} source {source}",
-    ),
-    ipv6_vpn=CommandSet(
-        bgp_route="show ipv6 bgp {target} vrf {vrf} | json",
-        bgp_aspath="show ipv6 bgp regexp {target} vrf {vrf} | json",
-        bgp_community="show ipv6 bgp community {target} vrf {vrf} | json",
-        ping="ping vrf {vrf} ipv6 {target} source {source}",
-        traceroute="traceroute vrf {vrf} ipv6 {target} source {source}",
-    ),
-)
 
 
 class AristaEOSCommands(CommandGroup):
@@ -88,6 +56,10 @@ class AristaEOSCommands(CommandGroup):
     ipv6_vpn: _VPNIPv6 = _VPNIPv6()
 
     def __init__(self, **kwargs):
-        """Initialize command group, ensure structured fields are not overridden."""
         super().__init__(**kwargs)
-        self.structured = _structured
+        self.structured = CommandGroup(
+            ipv4_default=self.ipv4_default,
+            ipv6_default=self.ipv6_default,
+            ipv4_vpn=self.ipv4_vpn,
+            ipv6_vpn=self.ipv6_vpn,
+        )

--- a/hyperglass/models/commands/juniper.py
+++ b/hyperglass/models/commands/juniper.py
@@ -10,9 +10,9 @@ from .common import CommandSet, CommandGroup
 class _IPv4(CommandSet):
     """Validation model for non-default dual afi commands."""
 
-    bgp_route: StrictStr = 'show route protocol bgp table inet.0 {target} best detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
-    bgp_aspath: StrictStr = 'show route protocol bgp table inet.0 aspath-regex "{target}"'
-    bgp_community: StrictStr = "show route protocol bgp table inet.0 community {target}"
+    bgp_route: StrictStr = "show route protocol bgp table inet.0 {target} best detail | display xml"
+    bgp_aspath: StrictStr = 'show route protocol bgp table inet.0 aspath-regex "{target}" detail | display xml'
+    bgp_community: StrictStr = "show route protocol bgp table inet.0 community {target} detail | display xml"
     ping: StrictStr = "ping inet {target} count 5 source {source}"
     traceroute: StrictStr = "traceroute inet {target} wait 1 source {source}"
 
@@ -20,9 +20,9 @@ class _IPv4(CommandSet):
 class _IPv6(CommandSet):
     """Validation model for non-default ipv4 commands."""
 
-    bgp_route: StrictStr = 'show route protocol bgp table inet6.0 {target} best detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
-    bgp_aspath: StrictStr = 'show route protocol bgp table inet6.0 aspath-regex "{target}"'
-    bgp_community: StrictStr = "show route protocol bgp table inet6.0 community {target}"
+    bgp_route: StrictStr = "show route protocol bgp table inet6.0 {target} best detail | display xml"
+    bgp_aspath: StrictStr = 'show route protocol bgp table inet6.0 aspath-regex "{target}" detail | display xml'
+    bgp_community: StrictStr = "show route protocol bgp table inet6.0 community {target} detail | display xml"
     ping: StrictStr = "ping inet6 {target} count 5 source {source}"
     traceroute: StrictStr = "traceroute inet6 {target} wait 2 source {source}"
 
@@ -30,9 +30,9 @@ class _IPv6(CommandSet):
 class _VPNIPv4(CommandSet):
     """Validation model for non-default ipv6 commands."""
 
-    bgp_route: StrictStr = 'show route protocol bgp table {vrf}.inet.0 {target} best detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
-    bgp_aspath: StrictStr = 'show route protocol bgp table {vrf}.inet.0 aspath-regex "{target}"'
-    bgp_community: StrictStr = "show route protocol bgp table {vrf}.inet.0 community {target}"
+    bgp_route: StrictStr = "show route protocol bgp table {vrf}.inet.0 {target} best detail | display xml"
+    bgp_aspath: StrictStr = 'show route protocol bgp table {vrf}.inet.0 aspath-regex "{target}" detail | display xml'
+    bgp_community: StrictStr = "show route protocol bgp table {vrf}.inet.0 community {target} detail | display xml"
     ping: StrictStr = "ping inet routing-instance {vrf} {target} count 5 source {source}"
     traceroute: StrictStr = "traceroute inet routing-instance {vrf} {target} wait 1 source {source}"
 
@@ -40,43 +40,11 @@ class _VPNIPv4(CommandSet):
 class _VPNIPv6(CommandSet):
     """Validation model for non-default ipv6 commands."""
 
-    bgp_route: StrictStr = 'show route protocol bgp table {vrf}.inet6.0 {target} best detail | except Label | except Label | except "Next hop type" | except Task | except Address | except "Session Id" | except State | except "Next-hop reference" | except destinations | except "Announcement bits"'
-    bgp_aspath: StrictStr = 'show route protocol bgp table {vrf}.inet6.0 aspath-regex "{target}"'
-    bgp_community: StrictStr = "show route protocol bgp table {vrf}.inet6.0 community {target}"
+    bgp_route: StrictStr = "show route protocol bgp table {vrf}.inet6.0 {target} best detail | display xml"
+    bgp_aspath: StrictStr = 'show route protocol bgp table {vrf}.inet6.0 aspath-regex "{target}" detail | display xml'
+    bgp_community: StrictStr = "show route protocol bgp table {vrf}.inet6.0 community {target} detail | display xml"
     ping: StrictStr = "ping inet6 routing-instance {vrf} {target} count 5 source {source}"
     traceroute: StrictStr = "traceroute inet6 routing-instance {vrf} {target} wait 2 source {source}"
-
-
-_structured = CommandGroup(
-    ipv4_default=CommandSet(
-        bgp_route="show route protocol bgp table inet.0 {target} best detail | display xml",
-        bgp_aspath='show route protocol bgp table inet.0 aspath-regex "{target}" detail | display xml',
-        bgp_community="show route protocol bgp table inet.0 community {target} detail | display xml",
-        ping="ping inet {target} count 5 source {source}",
-        traceroute="traceroute inet {target} wait 1 source {source}",
-    ),
-    ipv6_default=CommandSet(
-        bgp_route="show route protocol bgp table inet6.0 {target} best detail | display xml",
-        bgp_aspath='show route protocol bgp table inet6.0 aspath-regex "{target}" detail | display xml',
-        bgp_community="show route protocol bgp table inet6.0 community {target} detail | display xml",
-        ping="ping inet6 {target} count 5 source {source}",
-        traceroute="traceroute inet6 {target} wait 2 source {source}",
-    ),
-    ipv4_vpn=CommandSet(
-        bgp_route="show route protocol bgp table {vrf}.inet.0 {target} best detail | display xml",
-        bgp_aspath='show route protocol bgp table {vrf}.inet.0 aspath-regex "{target}" detail | display xml',
-        bgp_community="show route protocol bgp table {vrf}.inet.0 community {target} detail | display xml",
-        ping="ping inet routing-instance {vrf} {target} count 5 source {source}",
-        traceroute="traceroute inet routing-instance {vrf} {target} wait 1 source {source}",
-    ),
-    ipv6_vpn=CommandSet(
-        bgp_route="show route protocol bgp table {vrf}.inet6.0 {target} best detail | display xml",
-        bgp_aspath='show route protocol bgp table {vrf}.inet6.0 aspath-regex "{target}" detail | display xml',
-        bgp_community="show route protocol bgp table {vrf}.inet6.0 community {target} detail | display xml",
-        ping="ping inet6 routing-instance {vrf} {target} count 5 source {source}",
-        traceroute="traceroute inet6 routing-instance {vrf} {target} wait 2 source {source}",
-    ),
-)
 
 
 class JuniperCommands(CommandGroup):
@@ -88,6 +56,10 @@ class JuniperCommands(CommandGroup):
     ipv6_vpn: _VPNIPv6 = _VPNIPv6()
 
     def __init__(self, **kwargs):
-        """Initialize command group, ensure structured fields are not overridden."""
         super().__init__(**kwargs)
-        self.structured = _structured
+        self.structured = CommandGroup(
+            ipv4_default=self.ipv4_default,
+            ipv6_default=self.ipv6_default,
+            ipv4_vpn=self.ipv4_vpn,
+            ipv6_vpn=self.ipv6_vpn,
+        )


### PR DESCRIPTION
# Description

The suggested change allows to update the commands for arista and juniper devices.

# Motivation and Context

In the current version the commands.yaml settings are ignored if you select the "arista_eos" or "juniper" nos. This change allows to alter the commands.

# Test system

OS: Debian Bullseye
Python: 3.9
