### PR TITLE
Update install.sh: poetry link has changed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -422,7 +422,7 @@ install_redis() {
 install_app() {
     echo "[INFO] Installing hyperglass..."
 
-    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -o /tmp/get-poetry.py
+    curl -sSL https://install.python-poetry.org -o /tmp/get-poetry.py
     python3 /tmp/get-poetry.py -f -y >/dev/null
     sleep 1
     source $HOME/.profile


### PR DESCRIPTION
The poetry link has changed according to their official docs + Github page to https://install.python-poetry.org. Or, even better, you can use apt install python3-poetry for deb-based distro's

<!-- PLEASE CONSULT CONTRIBUTING.MD PRIOR TO WORKING ON HYPERGLASS -->

<!-- Provide a general summary of your changes in the Title. -->

# Description
Poetry no longer working: replace link

<!-- Describe your changes in detail -->
Replaced url; see commit

[INFO] Installing hyperglass...
  File "/tmp/get-poetry.py", line 1
    404: Not Found
    ^^^

