### PR TITLE
fix: website config

### DIFF
--- a/hyperglass/models/config/params.py
+++ b/hyperglass/models/config/params.py
@@ -91,7 +91,9 @@ class Params(ParamsPublic, HyperglassModel):
     web: Web = Web()
 
     def __init__(self, **kw: t.Any) -> None:
-        return super().__init__(**self.convert_paths(kw))
+        if "plugins" in kw:
+            kw["plugins"] = self.convert_paths(kw["plugins"])
+        return super().__init__(**kw)
 
     @field_validator("site_description")
     def validate_site_description(cls: "Params", value: str, info: ValidationInfo) -> str:


### PR DESCRIPTION
<!-- PLEASE CONSULT CONTRIBUTING.MD PRIOR TO WORKING ON HYPERGLASS -->

<!-- Provide a general summary of your changes in the Title. -->

# Description

When passing a `config.yaml`, every string value of the config parameters is prefixed with `/etc/hyperglass` in a Docker container.
![image](https://github.com/thatmattlove/hyperglass/assets/37785089/e0d04069-b015-4130-8889-edb7ab595eca)


# Tests

Tested manually with docker