### PR TITLE
feat: rootless container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM python:3.12.3-alpine as base
+# UI dependencies
+RUN apk add build-base pkgconfig cairo-dev nodejs npm
+# Setup rootless image
+RUN addgroup -g 1000 hyperglass && adduser -D -u 1000 -G hyperglass hyperglass
+RUN mkdir /etc/hyperglass /opt/hyperglass
+RUN chown -R hyperglass:hyperglass /etc/hyperglass /opt/hyperglass
+USER 1000:1000
 WORKDIR /opt/hyperglass
+COPY --chown=1000:1000 . .
 ENV HYPERGLASS_APP_PATH=/etc/hyperglass
 ENV HYPERGLASS_HOST=0.0.0.0
 ENV HYPERGLASS_PORT=8001
@@ -8,17 +16,19 @@ ENV HYPERGLASS_DEV_MODE=false
 ENV HYPERGLASS_REDIS_HOST=redis
 ENV HYPEGLASS_DISABLE_UI=true
 ENV HYPERGLASS_CONTAINER=true
-COPY . .
 
 FROM base as ui
+# Set NPM global install path to the home directory so permissions are correct
+RUN mkdir ~/.npm-global ~/.npm-store
+RUN npm config set prefix "~/.npm-global"
+ENV PATH="/home/hyperglass/.npm-global/bin:${PATH}"
 WORKDIR /opt/hyperglass/hyperglass/ui
-RUN apk add build-base pkgconfig cairo-dev nodejs npm
 RUN npm install -g pnpm
 RUN pnpm install -P
 
 FROM ui as hyperglass
 WORKDIR /opt/hyperglass
-RUN pip3 install -e .
+RUN pip3 install --user --no-cache-dir -e .
 
 EXPOSE ${HYPERGLASS_PORT}
 CMD ["python3", "-m", "hyperglass.console", "start"]


### PR DESCRIPTION
<!-- PLEASE CONSULT CONTRIBUTING.MD PRIOR TO WORKING ON HYPERGLASS -->

<!-- Provide a general summary of your changes in the Title. -->

# Description

This PR allow to run hyperglass in rootless mode, as it doesn't require root permissions.

# Related Issues

<!-- Link to any related open issues -->

# Motivation and Context

I want to configure the security context of the container in a Kubernetes environment. Unfortunately, for now, the container runs with root permissions.

# Tests

Tested manually on docker and on kubernetes with security context.
