### PR TITLE
fix: Update correct datatype for Arista extended communities

### DIFF
--- a/hyperglass/models/parsing/arista_eos.py
+++ b/hyperglass/models/parsing/arista_eos.py
@@ -65,7 +65,7 @@ class AristaRouteDetail(_AristaBase):
     origin: str
     label_stack: t.List = []
     ext_community_list: t.List[str] = []
-    ext_community_list_raw: t.List[str] = []
+    ext_community_list_raw: t.List[int] = []
     community_list: t.List[str] = []
     large_community_list: t.List[str] = []
 


### PR DESCRIPTION
# Description

This fixes a parsing issue where AristaRouteDetail expects a string for ext_community_list_raw but EOS returns an integer in the json formatted response

# Related Issues

https://github.com/thatmattlove/hyperglass/issues/252

# Motivation and Context

On some of our routers, we make use of extended communities. For each extended community in the `extCommunityListRaw` array returned by EOS, it is an integer and not returned as string. Example:
```
"extCommunityListRaw": [
    595497215591610,
    876972192302256
],
```

# Tests

When the `AristaRouteDetail` expects a string for `ext_community_list_raw`, the following error is produced:

```
[CRITICAL] 20240609 07:17:42 |66 | parse_arista → 11 validation errors for AristaBGPTable
bgpRouteEntries.`1.1.1.0/24`.bgpRoutePaths.0.routeDetail.extCommunityListRaw.0
  Input should be a valid string [type=string_type, input_value=595497215591610, input_type=int]
    For further information visit https://errors.pydantic.dev/2.7/v/string_type
bgpRouteEntries.`1.1.1.0/24`.bgpRoutePaths.0.routeDetail.extCommunityListRaw.1
  Input should be a valid string [type=string_type, input_value=876972192302256, input_type=int]
    For further information visit https://errors.pydantic.dev/2.7/v/string_type
bgpRouteEntries.`1.1.1.0/24`.bgpRoutePaths.1.routeDetail.extCommunityListRaw.0
```

When replaced with `int`, these parse errors no longer appear, and the table is rendered correctly.