### PR TITLE
Fix for IPv6 traceroute for juniper devices

### DIFF
--- a/hyperglass/defaults/directives/juniper.py
+++ b/hyperglass/defaults/directives/juniper.py
@@ -111,7 +111,7 @@ JuniperTraceroute = BuiltinDirective(
         RuleWithIPv6(
             condition="::/0",
             action="permit",
-            command="traceroute inet6 {target} wait 1 source {source6}",
+            command="traceroute inet6 {target} wait 2 source {source6}",
         ),
     ],
     field=Text(description="IP Address, Prefix, or Hostname"),


### PR DESCRIPTION
FIX for ipv6 traceroute on juniper devices

# Description

Juniper devices were failing traceroute for ipv6 targets with this error:
traceroute: wait must be >1 sec.

I just changed the wait time on juniper inet6 traceroute directive from 1 to 2

# Related Issues

Didn't open any issue

# Motivation and Context

IPv6 traceroute wasn't working on juniper devices

# Tests

Now it works correctly on all our juniper devices