### PR TITLE
Fix pylint warning `raise-missing-from`

### DIFF
--- a/hyperglass/cli/main.py
+++ b/hyperglass/cli/main.py
@@ -311,10 +311,9 @@ def _params(
                 )
             )
             raise typer.Exit(0)
-        except AttributeError:
+        except AttributeError as exc:
             echo.error(f"{'params.'+path!r} does not exist")
-            raise typer.Exit(1)
-
+            raise typer.Exit(1) from exc
     panel = Inspect(
         params,
         title="hyperglass Configuration Parameters",

--- a/hyperglass/compat/_sshtunnel.py
+++ b/hyperglass/compat/_sshtunnel.py
@@ -1541,11 +1541,11 @@ def _bindlist(input_str):
         else:
             (_ip, _port) = ip_port
         if not _ip and not _port:
-            raise AssertionError
+            raise AssertionError("Both IP:PORT can't be missing!")
         elif not _port:
             _port = "22"  # default port if not given
         return _ip, int(_port)
-    except ValueError:
-        raise argparse.ArgumentTypeError("Address tuple must be of type IP_ADDRESS:PORT")
-    except AssertionError:
-        raise argparse.ArgumentTypeError("Both IP:PORT can't be missing!")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Address tuple must be of type IP_ADDRESS:PORT") from exc
+    except AssertionError as exc:
+        raise argparse.ArgumentTypeError("Both IP:PORT can't be missing!") from exc

--- a/hyperglass/plugins/_manager.py
+++ b/hyperglass/plugins/_manager.py
@@ -117,12 +117,10 @@ class PluginManager(t.Generic[PluginT]):
                 else:
                     _log.info("Registered plugin")
                 return
-        except TypeError:
-            raise PluginError(  # noqa: B904
-                "Plugin '{p}' has not defined a required method. "
-                "Please consult the hyperglass documentation.",
-                p=repr(plugin),
-            )
+        except TypeError as exc:
+            raise PluginError("Plugin '{p}' has not defined a required method. "
+                              "Please consult the hyperglass documentation.",
+                              p=repr(plugin)) from exc
         raise PluginError("Plugin '{p}' is not a valid hyperglass plugin", p=repr(plugin))
 
 


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `raise-missing-from`.
"Python's exception chaining shows the traceback of the current exception, but also of the original exception. When you raise a new exception after another exception was caught it's likely that the second exception is a friendly re-wrapping of the first exception. In such cases `raise from` provides a better link between the two tracebacks in the final error. See [https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.