### PR TITLE
feat: allow javascript caching in docker environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,6 @@ hyperglass/ui/.env*
 hyperglass.json
 custom.*[js, html]
 .next
-out/
 fonts/
 __pycache__
 .python-version

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ __pycache__/
 .Python
 env/
 build/
+# keep hyperglass ui/build
+!**/ui/build/
 develop-eggs/
 dist/
 downloads/

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
             "node_modules",
             "dist",
             ".next/",
-            "out/",
+            "build/",
             "favicon-formats.ts",
             "custom.*[js, html]",
             "hyperglass.json"

--- a/hyperglass/ui/next.config.js
+++ b/hyperglass/ui/next.config.js
@@ -9,7 +9,7 @@ const nextConfig = {
   },
   swcMinify: true,
   productionBrowserSourceMaps: true,
-  distDir: "build/out",
+  distDir: 'build/out',
 };
 
 if (process.env.NODE_ENV === 'production') {

--- a/hyperglass/ui/next.config.js
+++ b/hyperglass/ui/next.config.js
@@ -9,6 +9,7 @@ const nextConfig = {
   },
   swcMinify: true,
   productionBrowserSourceMaps: true,
+  distDir: "build/out",
 };
 
 if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
# Description

Everything is noted in the issue.
There is an additional fix regarding the `build id` that also affects the current version and older ones where`model_dump` keys are not sorted, which could trigger a rebuild if the keys were swapped compared to the last build.

# Related Issues

Fixes #275

# Motivation and Context

I want to speed up pod restarts in my Kubernetes environment, so I need to avoid rebuilding the frontend every time.

# Tests

Tested in docker & kubernetes environment
