### PR TITLE
Fix typo in devices builtin configuration

### DIFF
--- a/docs/pages/configuration/devices.mdx
+++ b/docs/pages/configuration/devices.mdx
@@ -111,7 +111,7 @@ devices:
           username: you
           password: your password
       directives:
-          - builtin: false
+          - builtins: false
           - cisco-show-lldp-neighbors
 ```
 
@@ -131,5 +131,5 @@ devices:
           username: you
           password: your password
       directives:
-          - builtin: [bgp_route, traceroute]
+          - builtins: [bgp_route, traceroute]
 ```


### PR DESCRIPTION
<!-- PLEASE CONSULT CONTRIBUTING POLICY PRIOR TO WORKING ON HYPERGLASS -->

<!-- Provide a general summary of your changes in the Title. -->

# Description

Just fix a typo in the documentation

# Related Issues

None

# Motivation and Context

Documentation should always be correct

# Tests

None
