### PR TITLE
General QoL Improvements - Docker related

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.3-alpine as base
+FROM python:3.12.3-alpine AS base
 WORKDIR /opt/hyperglass
 ENV HYPERGLASS_APP_PATH=/etc/hyperglass
 ENV HYPERGLASS_HOST=0.0.0.0
@@ -10,13 +10,13 @@ ENV HYPEGLASS_DISABLE_UI=true
 ENV HYPERGLASS_CONTAINER=true
 COPY . .
 
-FROM base as ui
+FROM base AS ui
 WORKDIR /opt/hyperglass/hyperglass/ui
 RUN apk add build-base pkgconfig cairo-dev nodejs npm
 RUN npm install -g pnpm
 RUN pnpm install -P
 
-FROM ui as hyperglass
+FROM ui AS hyperglass
 WORKDIR /opt/hyperglass
 RUN pip3 install -e .
 

--- a/compose-self.yaml
+++ b/compose-self.yaml
@@ -3,6 +3,7 @@ services:
         image: "valkey/valkey:8-alpine"
 
     hyperglass:
+        build: .
         depends_on:
             - kv-storage
         environment:
@@ -15,7 +16,6 @@ services:
             - HYPEGLASS_DISABLE_UI=${HYPEGLASS_DISABLE_UI-false}
             - HYPERGLASS_CONTAINER=${HYPERGLASS_CONTAINER-true}
             - HYPERGLASS_ORIGINAL_APP_PATH=${HYPERGLASS_APP_PATH}
-        build: .
         ports:
             - "${HYPERGLASS_PORT-8001}:${HYPERGLASS_PORT-8001}"
         volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,10 @@
 services:
-    redis:
-        image: "redis:alpine"
+    kv-storage:
+        image: "valkey/valkey:8-alpine"
+
     hyperglass:
         depends_on:
-            - redis
+            - kv-storage
         environment:
             - HYPERGLASS_APP_PATH=/etc/hyperglass
             - HYPERGLASS_HOST=${HYPERGLASS_HOST-0.0.0.0}

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,11 +7,11 @@ services:
             - kv-storage
         environment:
             - HYPERGLASS_APP_PATH=/etc/hyperglass
+            - HYPERGLASS_REDIS_HOST=${HYPERGLASS_REDIS_HOST-kv-storage}
             - HYPERGLASS_HOST=${HYPERGLASS_HOST-0.0.0.0}
             - HYPERGLASS_PORT=${HYPERGLASS_PORT-8001}
             - HYPERGLASS_DEBUG=${HYPERGLASS_DEBUG-false}
             - HYPERGLASS_DEV_MODE=${HYPERGLASS_DEV_MODE-false}
-            - HYPERGLASS_REDIS_HOST=${HYPERGLASS_REDIS_HOST-redis}
             - HYPEGLASS_DISABLE_UI=${HYPEGLASS_DISABLE_UI-false}
             - HYPERGLASS_CONTAINER=${HYPERGLASS_CONTAINER-true}
             - HYPERGLASS_ORIGINAL_APP_PATH=${HYPERGLASS_APP_PATH}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,22 @@
+services:
+    kv-storage:
+        image: "valkey/valkey:8-alpine"
+
+    hyperglass:
+        image: ghcr.io/thatmattlove/hyperglass:main
+        depends_on:
+            - kv-storage
+        environment:
+            - HYPERGLASS_APP_PATH=/etc/hyperglass
+            - HYPERGLASS_REDIS_HOST=${HYPERGLASS_REDIS_HOST-kv-storage}
+            - HYPERGLASS_HOST=${HYPERGLASS_HOST-0.0.0.0}
+            - HYPERGLASS_PORT=${HYPERGLASS_PORT-8001}
+            - HYPERGLASS_DEBUG=${HYPERGLASS_DEBUG-false}
+            - HYPERGLASS_DEV_MODE=${HYPERGLASS_DEV_MODE-false}
+            - HYPEGLASS_DISABLE_UI=${HYPEGLASS_DISABLE_UI-false}
+            - HYPERGLASS_CONTAINER=${HYPERGLASS_CONTAINER-true}
+            - HYPERGLASS_ORIGINAL_APP_PATH=${HYPERGLASS_APP_PATH}
+        ports:
+            - "${HYPERGLASS_PORT-8001}:${HYPERGLASS_PORT-8001}"
+        volumes:
+            - ./data:/etc/hyperglass

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,7 @@ services:
 
     hyperglass:
         image: ghcr.io/thatmattlove/hyperglass:main
+        restart: unless-stopped
         depends_on:
             - kv-storage
         environment:

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -2,6 +2,7 @@ import { Cards } from "nextra/components";
 
 <Cards>
     <Cards.Card href="installation/docker" title="Using Docker" />
+    <Cards.Card href="installation/docker-ghcr" title="Using Docker (GHCR)" />
     <Cards.Card href="installation/manual" title="Manual Installation" />
 </Cards>
 

--- a/docs/pages/installation/docker-ghcr.mdx
+++ b/docs/pages/installation/docker-ghcr.mdx
@@ -1,0 +1,49 @@
+---
+title: Using Docker
+description: Installing hyperglass with Docker
+---
+
+import { Cards, Steps, Callout } from "nextra/components";
+// import { Callout } from "nextra-theme-docs";
+
+<Callout type="info">**Docker is the recommended method for running hyperglass.**</Callout>
+
+<Steps>
+
+### Install Docker
+
+<Cards>
+    <Cards.Card
+        title="Docker Engine Installation Guide"
+        href="https://docs.docker.com/engine/install/"
+        target="_blank"
+        arrow
+    />
+</Cards>
+
+### Download hyperglass
+
+```shell copy
+mkdir /home/hyperglass
+cd /home/hyperglass
+wget "https://github.com/thatmattlove/hyperglass/blob/main/compose.yaml"
+```
+
+### Optional: Quickstart
+
+Do this if you just want to see the hyperglass page working with a fake device.
+
+```shell copy
+mkdir data
+wget -O ./data/devices.yaml "https://raw.githubusercontent.com/thatmattlove/hyperglass/refs/heads/main/.samples/sample_devices.yaml"
+docker compose up
+```
+
+Navigate to http://IPADDRESS:8001
+
+### Enable auto-restart
+
+You may want to ensure that Hyperglass stays running even after a reboot.
+To do this, you can easily change the "restart" parameter in `compose.yaml` to `always`.
+
+</Steps>


### PR DESCRIPTION
<!-- PLEASE CONSULT CONTRIBUTING POLICY PRIOR TO WORKING ON HYPERGLASS -->

<!-- Provide a general summary of your changes in the Title. -->

# Description

Hyperglass can now be used directly from GHCR, without needing to clone the full git repository. 
Build caching has been improved, so that it is not needed to fully download all the dependencies at each change, but only when the dependencies change. 
Redis has been replaced with valkey, due to license changes.

# Motivation and Context

Cloning a full repo and having to deal with configuration files is against the purpose of Docker simplicity, in my view. 
This allows to just have a `compose.yaml` file and be ready to go, without having to deal with other things. This also allows easier integration in systems where you can only deploy containers from Registries. 

# Tests

Verified with GitHub CI + MacOS (Apple Silicon) - Everything works as expected. 
Requires #297 to be merged.