### PR TITLE
Fix: allow integer values in ext_community_list_raw field for Arista BGP…

### DIFF
--- a/hyperglass/models/parsing/arista_eos.py
+++ b/hyperglass/models/parsing/arista_eos.py
@@ -2,7 +2,6 @@
 
 # Standard Library
 import typing as t
-from typing import Union
 from datetime import datetime
 
 # Third Party
@@ -66,7 +65,7 @@ class AristaRouteDetail(_AristaBase):
     origin: str
     label_stack: t.List = []
     ext_community_list: t.List[str] = []
-    ext_community_list_raw: t.List[Union[str, int]] = []
+    ext_community_list_raw: t.List[t.Union[str, int]] = []
     community_list: t.List[str] = []
     large_community_list: t.List[str] = []
 

--- a/hyperglass/models/parsing/arista_eos.py
+++ b/hyperglass/models/parsing/arista_eos.py
@@ -65,8 +65,8 @@ class AristaRouteDetail(_AristaBase):
 
     origin: str
     label_stack: t.List = []
+    ext_community_list: t.List[str] = []
     ext_community_list_raw: t.List[Union[str, int]] = []
-    ext_community_list_raw: t.List[str] = []
     community_list: t.List[str] = []
     large_community_list: t.List[str] = []
 

--- a/hyperglass/models/parsing/arista_eos.py
+++ b/hyperglass/models/parsing/arista_eos.py
@@ -2,6 +2,7 @@
 
 # Standard Library
 import typing as t
+from typing import Union
 from datetime import datetime
 
 # Third Party
@@ -64,7 +65,7 @@ class AristaRouteDetail(_AristaBase):
 
     origin: str
     label_stack: t.List = []
-    ext_community_list: t.List[str] = []
+    ext_community_list_raw: t.List[Union[str, int]] = []
     ext_community_list_raw: t.List[str] = []
     community_list: t.List[str] = []
     large_community_list: t.List[str] = []


### PR DESCRIPTION
# Description
Fix: allow integer values in ext_community_list_raw field for Arista BGP parsing

This fix resolves validation errors by modifying the parsing logic to accept both integer and string types for the 'ext_community_list_raw' field in Arista device BGP route data.

# Related Issues
Fixes #305 

# Motivation and Context
The current implementation strictly requires string inputs for ext_community_list_raw, causing validation errors when integer values are received from Arista devices. We were experiencing this issue ourselves and these changes appear to have resolved the issue.

# Tests
- Verified parsing of ext_community_list_raw with integer values: 595497215590410, 595497215590424, etc.
- Confirmed successful BGP route table parsing on Arista EOS devices.
- Confirmed error messages in original issue no longer appear.
