### PR TITLE
Fix code block padding in the documentation

### DIFF
--- a/docs/pages/plugins.mdx
+++ b/docs/pages/plugins.mdx
@@ -60,13 +60,13 @@ ip_route_directive:
 
 When the query is received, the query target is transformed, resulting in this being sent to the device:
 
-```
+```text
 show ip route 192.0.2.0 255.255.255.0
 ```
 
 instead of:
 
-```
+```text
 show ip route 192.0.2.0/24
 ```
 


### PR DESCRIPTION
# Description

This fixes a minor formatting issues on the [plugins](https://hyperglass.dev/plugins) page in documentation by specifying the code block language as text for the two `show ip route` examples.

# Related Issues

# Motivation and Context

The two code blocks on the plugin page does not have any padding to the left and looks a bit out of place compared to other code blocks in the documentation.

# Tests