### PR TITLE
Fix huawei bgp route and plugin validation/transform order

### DIFF
--- a/hyperglass/defaults/directives/huawei.py
+++ b/hyperglass/defaults/directives/huawei.py
@@ -27,15 +27,16 @@ Huawei_BGPRoute = BuiltinDirective(
         RuleWithIPv4(
             condition="0.0.0.0/0",
             action="permit",
-            command="display bgp routing-table {target}",
+            command="display bgp routing-table {target} | no-more",
         ),
         RuleWithIPv6(
             condition="::/0",
             action="permit",
-            command="display bgp ipv6 routing-table {target}",
+            command="display bgp ipv6 routing-table {target} | no-more",
         ),
     ],
     field=Text(description="IP Address, Prefix, or Hostname"),
+    plugins=["bgp_route_huawei"],
     platforms=PLATFORMS,
 )
 

--- a/hyperglass/models/api/query.py
+++ b/hyperglass/models/api/query.py
@@ -65,12 +65,12 @@ class Query(BaseModel):
 
         self._input_plugin_manager = InputPluginManager()
 
-        self.query_target = self.transform_query_target()
-
         try:
             self.validate_query_target()
         except InputValidationError as err:
             raise InputInvalid(**err.kwargs) from err
+        
+        self.query_target = self.transform_query_target()
 
     def summary(self) -> SimpleQuery:
         """Summarized and post-validated model of a Query."""

--- a/hyperglass/plugins/_builtin/__init__.py
+++ b/hyperglass/plugins/_builtin/__init__.py
@@ -5,10 +5,12 @@ from .remove_command import RemoveCommand
 from .bgp_route_arista import BGPRoutePluginArista
 from .bgp_route_juniper import BGPRoutePluginJuniper
 from .mikrotik_garbage_output import MikrotikGarbageOutput
+from .bgp_route_huawei import BGPRoutePluginHuawei
 
 __all__ = (
     "BGPRoutePluginArista",
     "BGPRoutePluginJuniper",
+    "BGPRoutePluginHuawei",
     "MikrotikGarbageOutput",
     "RemoveCommand",
 )

--- a/hyperglass/plugins/_builtin/bgp_route_huawei.py
+++ b/hyperglass/plugins/_builtin/bgp_route_huawei.py
@@ -1,0 +1,42 @@
+from ipaddress import ip_network
+from .._input import InputPlugin
+
+# Standard Library
+import typing as t
+
+# Third Party
+from pydantic import PrivateAttr
+
+if t.TYPE_CHECKING:
+    # Project
+    from hyperglass.models.api.query import Query
+
+InputPluginTransformReturn = t.Union[t.Sequence[str], str]
+
+class BGPRoutePluginHuawei(InputPlugin):
+    _hyperglass_builtin: bool = PrivateAttr(True)
+    platforms: t.Sequence[str] =("huawei", "huawei_vrpv8",)
+    directives: t.Sequence[str] = ("__hyperglass_huawei_bgp_route__",)
+    
+    """
+    Huawei BGP Route Input Plugin
+    
+    This plugin transforms a query target into a network address and prefix length
+    ex.: 192.0.2.0/24 ->  192.0.2.0 24
+    ex.: 2001:db8::/32 -> 2001:db8:: 32
+    """
+    def transform(self, query: "Query") -> InputPluginTransformReturn:
+        (target := query.query_target)
+        
+        if not target or not isinstance(target, list) or len(target) == 0:
+            return None
+        
+        target = target[0].strip()
+
+        # Check for the / in the query target
+        if target.find("/") == -1:
+            return target
+
+        target_network = ip_network(target)
+        
+        return f"{target_network.network_address!s} {target_network.prefixlen!s}"


### PR DESCRIPTION
<!-- PLEASE CONSULT CONTRIBUTING POLICY PRIOR TO WORKING ON HYPERGLASS -->

<!-- Provide a general summary of your changes in the Title. -->

# Description

<!-- Describe your changes in detail -->

* Fixed bgp route timeout by adding `| no-more` to the command, disableing the CLI pagination
* Created a builtin plugin to transform the `IP/MASK` to `IP MASK` as accepted by the Huawei CLI
* Fixed the plugins to validade the rules and then transform the input, or else, the transform will break validation

# Related Issues

<!-- Link to any related open issues -->
Fixes #315 #187

# Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Some built-in directives do not work on Huawei devices and Huawei routers are very popular in Brazil.

# Tests

<!-- Please describe in detail how you tested your changes, including your testing environment (OS, Python version, etc). -->
Tested changes on Debian 13 (trixie/sid) with Podman 4.9.3. All tests were made building the image with the compose file and executed as container, so Python, Next and everything else were in the versions defined on the Dockerfile.
Tested on two Huawei NE8000 Routers with multiple inputs: IPv4, IPv6, IPv4/mask, IPv6/mask