### PR TITLE
Fix validation in directives and devices

### DIFF
--- a/docs/pages/configuration/directives.mdx
+++ b/docs/pages/configuration/directives.mdx
@@ -166,6 +166,7 @@ your-directive:
         - condition: null
           command: show ip route {target}
     field:
+        description: IP of target
         validation: '[0-9a-f\.\:]+'
 ```
 
@@ -178,6 +179,7 @@ your-directive:
         - condition: null
           command: show ip bgp community {target}
     field:
+        description: BGP community to show
         options:
             - value: "65001:1"
               description: Provider A Routes

--- a/hyperglass/models/api/query.py
+++ b/hyperglass/models/api/query.py
@@ -7,7 +7,8 @@ import secrets
 from datetime import datetime
 
 # Third Party
-from pydantic import Field, BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, StringConstraints
+from typing_extensions import Annotated
 
 # Project
 from hyperglass.log import log
@@ -19,6 +20,11 @@ from hyperglass.exceptions.private import InputValidationError
 
 # Local
 from ..config.devices import Device
+
+
+QueryLocation = Annotated[str, StringConstraints(strict=True, min_length=1, strip_whitespace=True)]
+QueryTarget = Annotated[str, StringConstraints(min_length=1, strip_whitespace=True)]
+QueryType = Annotated[str, StringConstraints(strict=True, min_length=1, strip_whitespace=True)]
 
 
 class SimpleQuery(BaseModel):
@@ -39,12 +45,12 @@ class Query(BaseModel):
     model_config = ConfigDict(extra="allow", alias_generator=snake_to_camel, populate_by_name=True)
 
     # Device `name` field
-    query_location: str = Field(strict=True, min_length=1, strip_whitespace=True)
+    query_location: QueryLocation
 
-    query_target: t.Union[t.List[str], str] = Field(min_length=1, strip_whitespace=True)
+    query_target: t.Union[t.List[QueryTarget], QueryTarget]
 
     # Directive `id` field
-    query_type: str = Field(strict=True, min_length=1, strip_whitespace=True)
+    query_type: QueryType
     _kwargs: t.Dict[str, t.Any]
 
     def __init__(self, **data) -> None:

--- a/hyperglass/models/directive.py
+++ b/hyperglass/models/directive.py
@@ -282,14 +282,15 @@ class Directive(HyperglassUniqueModel, unique_by=("id", "table_output")):
                 condition = rule.get("condition")
                 if condition is None:
                     out_rules.append(RuleWithoutValidation(**rule))
-                try:
-                    condition_net = ip_network(condition)
-                    if condition_net.version == 4:
-                        out_rules.append(RuleWithIPv4(**rule))
-                    if condition_net.version == 6:
-                        out_rules.append(RuleWithIPv6(**rule))
-                except ValueError:
-                    out_rules.append(RuleWithPattern(**rule))
+                else:
+                    try:
+                        condition_net = ip_network(condition)
+                        if condition_net.version == 4:
+                            out_rules.append(RuleWithIPv4(**rule))
+                        if condition_net.version == 6:
+                            out_rules.append(RuleWithIPv6(**rule))
+                    except ValueError:
+                        out_rules.append(RuleWithPattern(**rule))
             if isinstance(rule, Rule):
                 out_rules.append(rule)
         return out_rules


### PR DESCRIPTION
# Description
This PR fixes multiple validation related issues

1. Some of the field validator methods for device config used `values` as a dictionary (presumably from an old version of pydantic). This is now passed as a `ValidationInfo` object by pydantic, which caused issues when code attempted to access it. The affected methods have been updated to fix the issue.
2. Previously, when processing rules with no condition, an extra RuleWithPattern rule was also added to the rule list causing a validation error. This behaviour has been prevented meaning only a RuleWithoutValidation rule is added.
3. Update docs so they include required options for `field` in the examples.
4. Fixed API docs rendering. The use of `strip_whitespace` in `Field` for the query validation model caused the automatic generation of the API docs to fail with `ValueError: `schema_extra` declares key `strip_whitespace` which does not exist in `Schema` object`. By switching from `Field` to `Annotated` with `StringConstraints`, this avoids this issue allowing API docs to be correctly rendered.


# Related Issues

Fix #311

# Motivation and Context

I am currently deploying hyperglass and have run into a few issues with config validation and I am fixing them as I encounter them.

Previously hyperglass would crash when starting with various configurations.

# Tests

Manual testing of fixes before and after to ensure issues do not persist after change.
