### PR TITLE
Fix custom proxy port support in SSH proxy tunnels

### DIFF
--- a/hyperglass/execution/drivers/ssh.py
+++ b/hyperglass/execution/drivers/ssh.py
@@ -48,7 +48,9 @@ class SSHConnection(Connection):
                         proxy.credential.password.get_secret_value()
                     )
             try:
-                return open_tunnel(ssh_address_or_host=proxy._target, ssh_port=proxy.port, **tunnel_kwargs)
+                return open_tunnel(
+                    ssh_address_or_host=proxy._target, ssh_port=proxy.port, **tunnel_kwargs
+                )
 
             except BaseSSHTunnelForwarderError as scrape_proxy_error:
                 log.bind(device=self.device.name, proxy=proxy.name).error(

--- a/hyperglass/execution/drivers/ssh.py
+++ b/hyperglass/execution/drivers/ssh.py
@@ -48,7 +48,7 @@ class SSHConnection(Connection):
                         proxy.credential.password.get_secret_value()
                     )
             try:
-                return open_tunnel(proxy._target, proxy.port, **tunnel_kwargs)
+                return open_tunnel(ssh_address_or_host=proxy._target, ssh_port=proxy.port, **tunnel_kwargs)
 
             except BaseSSHTunnelForwarderError as scrape_proxy_error:
                 log.bind(device=self.device.name, proxy=proxy.name).error(


### PR DESCRIPTION
### Description

This PR ensures that the proxy.port value defined in devices.yaml is correctly passed into the SSH tunnel constructor. Previously Hyperglass always fell back to port 22 when opening a proxy tunnel, even if you specified a different port.

### Motivation and Context

Operators might need to run their SSH jump hosts on non-standard ports (for example, 61440). Until now, those custom proxy.port settings were ignored, preventing Hyperglass from ever reaching the proxy on the intended port.

### Tests
	1.	Manually set proxy.port: 61440 in devices.yaml and rebuilt/restarted the service. Verified in the debug log that SSH connections are now attempted on port 61440 instead of 22.