### PR TITLE
FRR: Handle empty results and missing attributes properly

### DIFF
--- a/hyperglass/models/parsing/frr.py
+++ b/hyperglass/models/parsing/frr.py
@@ -31,9 +31,9 @@ class FRRNextHop(_FRRBase):
 
     ip: str
     afi: str
-    metric: int
+    metric: int = 0
     accessible: bool
-    used: bool
+    used: bool = False
 
 
 class FRRPeer(_FRRBase):

--- a/hyperglass/models/parsing/frr.py
+++ b/hyperglass/models/parsing/frr.py
@@ -65,7 +65,15 @@ class FRRPath(_FRRBase):
     def validate_path(cls, values):
         """Extract meaningful data from FRR response."""
         new = values.copy()
-        new["aspath"] = values["aspath"]["segments"][0]["list"]
+        # Local prefixes (i.e. those in the same ASN) usually have
+        # no AS_PATH.
+        # Set AS_PATH to AS0 for now as we cannot ensure that the
+        # ASN for the prefix is the primary ASN.
+        if values["aspath"]["length"] != 0:
+            new["aspath"] = values["aspath"]["segments"][0]["list"]
+        else:
+            # TODO: Get an ASN that is reasonable (e.g. primary ASN)
+            new["aspath"] = [0]
         community = values.get("community", {"list": []})
         new["community"] = community["list"]
         new["lastUpdate"] = values["lastUpdate"]["epoch"]

--- a/hyperglass/plugins/_builtin/bgp_route_frr.py
+++ b/hyperglass/plugins/_builtin/bgp_route_frr.py
@@ -36,6 +36,10 @@ def parse_frr(output: t.Sequence[str]) -> "OutputDataModel":
 
             _log.debug("Pre-parsed data", data=parsed)
 
+            # If empty (i.e. no route found), skip
+            if not parsed:
+                continue
+
             validated = FRRBGPTable(**parsed)
             bgp_table = validated.bgp_table()
 


### PR DESCRIPTION
# Description

This PR fixes three edge cases in the FRR parser that cause failures:

1. Empty route query results (when a route is not in the RIB)
2. Missing optional fields (`metric` and `used`) on next-hops in multipath routes
3. Local prefixes with zero-length `AS_PATH`

Please see individual commit messages for detailed explanations and examples.

# Related Issues

None that I could find.

# Motivation and Context

When I set up hyperglass backed by an FRR instance I noticed that some edge cases cause the parser to fail (like a route that's not in the DFZ and so on).

# Tests

**Test Environment**: Docker on Ubuntu 24.04, with FRR as device

**Devices Tested**: FRR 10.4.1 with bgpd enabled

**Test Cases:**
- Empty route queries (routes not in RIB)
- Multipath routes with missing optional next-hop attributes
- Local prefixes with zero-length AS_PATH