### PR TITLE
fix(docker): pin pnpm 10 to honor onlyBuiltDependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 FROM base as ui
 WORKDIR /opt/hyperglass/hyperglass/ui
 RUN apk add build-base pkgconfig cairo-dev nodejs npm
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 RUN pnpm install -P
 
 FROM ui as hyperglass


### PR DESCRIPTION
Install pnpm@10 in the Docker image instead of the floating latest version. hyperglass runs `pnpm install` during UI initialization, and newer pnpm behavior causes startap failure:

hyperglass-1  | [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @biomejs/biome@1.5.3, hyperglass-1  | esbuild@0.19.12
hyperglass-1  |
hyperglass-1  | Run "pnpm approve-builds" to pick which dependencies should be allowed to run hyperglass-1  | scripts.
hyperglass-1  | Errors:
hyperglass-1  |

Fixes #362.

<!-- PLEASE CONSULT CONTRIBUTING POLICY PRIOR TO WORKING ON HYPERGLASS -->

<!-- Provide a general summary of your changes in the Title. -->

# Description, Motivation and Context

See #362.

# Tests

With this fix and the fix for #348 I've manage to run hyperglass.
