### PR TITLE
fix(api): retry transient state-initialization errors (1/10)

### DIFF
--- a/hyperglass/api/state.py
+++ b/hyperglass/api/state.py
@@ -1,27 +1,52 @@
 """hyperglass state dependencies."""
 
 # Standard Library
+import asyncio
 import typing as t
 
 # Project
-from hyperglass.state import use_state
+from hyperglass.state import HyperglassState, use_state
+from hyperglass.exceptions.private import StateError
+
+
+def _is_retryable(attr: t.Optional[str]) -> bool:
+    """Whether a StateError for this attr is a transient (not-yet-populated) error.
+
+    A request can arrive before the Redis-backed state is populated on startup,
+    which surfaces as a StateError. Referencing an attribute that does not exist
+    on HyperglassState is a permanent programming error and must not be retried.
+    """
+    return attr is None or attr in ("cache", "redis") or attr in HyperglassState.properties()
+
+
+async def _get_state_with_retry(
+    attr: t.Optional[str] = None, max_retries: int = 5, retry_delay: float = 0.5
+) -> t.Any:
+    """Get hyperglass state, retrying transient startup StateErrors."""
+    for attempt in range(1, max_retries + 1):
+        try:
+            return use_state(attr)
+        except StateError:
+            if not _is_retryable(attr) or attempt == max_retries:
+                raise
+            await asyncio.sleep(retry_delay)
 
 
 async def get_state(attr: t.Optional[str] = None):
     """Get hyperglass state as a FastAPI dependency."""
-    return use_state(attr)
+    return await _get_state_with_retry(attr)
 
 
 async def get_params():
     """Get hyperglass params as FastAPI dependency."""
-    return use_state("params")
+    return await _get_state_with_retry("params")
 
 
 async def get_devices():
     """Get hyperglass devices as FastAPI dependency."""
-    return use_state("devices")
+    return await _get_state_with_retry("devices")
 
 
 async def get_ui_params():
     """Get hyperglass ui_params as FastAPI dependency."""
-    return use_state("ui_params")
+    return await _get_state_with_retry("ui_params")


### PR DESCRIPTION
## Summary
On startup, a request can reach the API before the Redis-backed application state is fully populated. The state dependencies (`get_state`/`get_params`/`get_devices`/`get_ui_params`) raise `StateError` in that window, which surfaces to the client as a `400`. This adds a bounded retry-with-delay (5 attempts, 0.5s) around those dependencies so transient startup races resolve themselves. A `StateError` for a *non-existent* attribute is a programming error and is re-raised immediately rather than retried.

## Notes
- No configuration or user-facing surface — pure reliability fix.

---
**Stacked series (1/10).** Base of the series; builds directly on `main`.

### Fixes
- Eliminates intermittent **HTTP 400** responses on startup, when a request arrives before the Redis-backed state is fully populated (state-initialization race).