### PR TITLE
feat(rpki): pluggable external RPKI backend with Routinator support (2/10)

### DIFF
--- a/docs/pages/configuration/config/structured-output.mdx
+++ b/docs/pages/configuration/config/structured-output.mdx
@@ -8,13 +8,17 @@ Devices that support responding to a query with structured or easily parsable da
 When structured output is available, hyperglass checks the RPKI state of each BGP prefix returned using one of two methods:
 
 1. From the router's perspective
-2. From the perspective of [Cloudflare's RPKI Service](https://rpki.cloudflare.com/)
+2. From an external validator — either [Cloudflare's RPKI Service](https://rpki.cloudflare.com/) (the default) or a self-hosted [Routinator](https://routinator.docs.nlnetlabs.nl/) instance
+
+When `structured.rpki.mode` is `external`, the `structured.rpki.backend` field selects which validator to query. The `cloudflare` backend uses Cloudflare's GraphQL API; the `routinator` backend queries the `/validity` HTTP API of a Routinator instance at `structured.rpki.rpki_server_url`.
 
 Additionally, hyperglass provides the ability to control which BGP communities are shown to the end user.
 
 | Parameter                      | Type            | Default Value | Description                                                                                                                   |
 | :----------------------------- | :-------------- | :------------ | :---------------------------------------------------------------------------------------------------------------------------- |
-| `structured.rpki.mode`         | String          | router        | Use `router` to use the router's view of the RPKI state (1 above), or `external` to use Cloudflare's view (2 above).          |
+| `structured.rpki.mode`         | String          | router        | Use `router` to use the router's view of the RPKI state (1 above), or `external` to use an external validator (2 above).      |
+| `structured.rpki.backend`      | String          | cloudflare    | When `mode` is `external`, the validator to use: `cloudflare` or `routinator`.                                               |
+| `structured.rpki.rpki_server_url` | String       |               | Base URL of the Routinator instance. **Required** when `backend` is `routinator` (e.g. `http://routinator.example.net:8323`). |
 | `structured.communities.mode`  | String          | deny          | Use `deny` to deny any communities listed in `structured.communities.items`, or `permit` to _only_ permit communities listed. |
 | `structured.communities.items` | List of Strings |               | List of communities to match.                                                                                                 |
 
@@ -28,12 +32,23 @@ structured:
         mode: router
 ```
 
-#### Show RPKI State from a Public/External Perspective
+#### Show RPKI State from a Public/External Perspective (Cloudflare)
 
-```yaml filename="config.yaml" copy {2}
+```yaml filename="config.yaml" copy {2-3}
 structured:
     rpki:
         mode: external
+        backend: cloudflare
+```
+
+#### Validate RPKI State Against a Self-Hosted Routinator
+
+```yaml filename="config.yaml" copy {2-5}
+structured:
+    rpki:
+        mode: external
+        backend: routinator
+        rpki_server_url: "http://routinator.example.net:8323"
 ```
 
 ### Community Filtering Examples

--- a/hyperglass/api/state.py
+++ b/hyperglass/api/state.py
@@ -1,27 +1,52 @@
 """hyperglass state dependencies."""
 
 # Standard Library
+import asyncio
 import typing as t
 
 # Project
-from hyperglass.state import use_state
+from hyperglass.state import HyperglassState, use_state
+from hyperglass.exceptions.private import StateError
+
+
+def _is_retryable(attr: t.Optional[str]) -> bool:
+    """Whether a StateError for this attr is a transient (not-yet-populated) error.
+
+    A request can arrive before the Redis-backed state is populated on startup,
+    which surfaces as a StateError. Referencing an attribute that does not exist
+    on HyperglassState is a permanent programming error and must not be retried.
+    """
+    return attr is None or attr in ("cache", "redis") or attr in HyperglassState.properties()
+
+
+async def _get_state_with_retry(
+    attr: t.Optional[str] = None, max_retries: int = 5, retry_delay: float = 0.5
+) -> t.Any:
+    """Get hyperglass state, retrying transient startup StateErrors."""
+    for attempt in range(1, max_retries + 1):
+        try:
+            return use_state(attr)
+        except StateError:
+            if not _is_retryable(attr) or attempt == max_retries:
+                raise
+            await asyncio.sleep(retry_delay)
 
 
 async def get_state(attr: t.Optional[str] = None):
     """Get hyperglass state as a FastAPI dependency."""
-    return use_state(attr)
+    return await _get_state_with_retry(attr)
 
 
 async def get_params():
     """Get hyperglass params as FastAPI dependency."""
-    return use_state("params")
+    return await _get_state_with_retry("params")
 
 
 async def get_devices():
     """Get hyperglass devices as FastAPI dependency."""
-    return use_state("devices")
+    return await _get_state_with_retry("devices")
 
 
 async def get_ui_params():
     """Get hyperglass ui_params as FastAPI dependency."""
-    return use_state("ui_params")
+    return await _get_state_with_retry("ui_params")

--- a/hyperglass/external/rpki.py
+++ b/hyperglass/external/rpki.py
@@ -3,57 +3,83 @@
 # Standard Library
 import typing as t
 
+# Third Party
+import httpx
+
 # Project
 from hyperglass.log import log
 from hyperglass.state import use_state
 from hyperglass.external._base import BaseExternal
 
 if t.TYPE_CHECKING:
-    # Standard Library
     from ipaddress import IPv4Address, IPv6Address
 
-RPKI_STATE_MAP = {"Invalid": 0, "Valid": 1, "NotFound": 2, "DEFAULT": 3}
-RPKI_NAME_MAP = {v: k for k, v in RPKI_STATE_MAP.items()}
+# Maps normalized (lower-case, separators stripped) backend state names to the
+# integer states hyperglass uses internally.
+RPKI_STATE_MAP = {
+    "invalid": 0,
+    "valid": 1,
+    "notfound": 2,
+    "unknown": 2,
+    "default": 3,
+}
+# Canonical integer -> display name, kept stable for logging.
+RPKI_NAME_MAP = {0: "Invalid", 1: "Valid", 2: "NotFound", 3: "DEFAULT"}
 CACHE_KEY = "hyperglass.external.rpki"
 
 
-def rpki_state(prefix: t.Union["IPv4Address", "IPv6Address", str], asn: t.Union[int, str]) -> int:
+def _normalize_state(value: str) -> int:
+    """Normalize a backend RPKI state string to an internal integer state."""
+    key = str(value).strip().lower().replace("-", "").replace("_", "")
+    return RPKI_STATE_MAP.get(key, 3)
+
+
+def rpki_state(
+    prefix: t.Union["IPv4Address", "IPv6Address", str],
+    asn: t.Union[int, str],
+    backend: str = "cloudflare",
+    rpki_server_url: str = "",
+) -> int:
     """Get RPKI state and map to expected integer."""
     _log = log.bind(prefix=prefix, asn=asn)
     _log.debug("Validating RPKI State")
 
     cache = use_state("cache")
-
     state = 3
     ro = f"{prefix!s}@{asn!s}"
 
     cached = cache.get_map(CACHE_KEY, ro)
-
     if cached is not None:
         state = cached
     else:
-        ql = 'query GetValidation {{ validation(prefix: "{}", asn: {}) {{ state }} }}'
-        query = ql.format(prefix, asn)
-        _log.bind(query=query).debug("Cloudflare RPKI GraphQL Query")
         try:
-            with BaseExternal(base_url="https://rpki.cloudflare.com") as client:
-                response = client._post("/api/graphql", data={"query": query})
-            try:
+            if backend == "cloudflare":
+                ql = 'query GetValidation {{ validation(prefix: "{}", asn: {}) {{ state }} }}'
+                query = ql.format(prefix, asn)
+                _log.bind(query=query).debug("Cloudflare RPKI GraphQL Query")
+                with BaseExternal(base_url="https://rpki.cloudflare.com") as client:
+                    response = client._post("/api/graphql", data={"query": query})
                 validation_state = response["data"]["validation"]["state"]
-            except KeyError as missing:
-                _log.error("Response from Cloudflare missing key '{}': {!r}", missing, response)
-                validation_state = 3
+            elif backend == "routinator":
+                url = f"{rpki_server_url.rstrip('/')}/validity"
+                _log.bind(url=url).debug("Routinator RPKI HTTP Query")
+                response = httpx.get(
+                    url, params={"asn": str(asn), "prefix": str(prefix)}, timeout=5
+                )
+                response.raise_for_status()
+                data = response.json()
+                validation_state = data["validated_route"]["validity"]["state"]
+            else:
+                raise ValueError(f"Unknown RPKI backend: {backend}")
 
-            state = RPKI_STATE_MAP[validation_state]
+            state = _normalize_state(validation_state)
             cache.set_map_item(CACHE_KEY, ro, state)
         except Exception as err:
             log.error(err)
-            # Don't cache the state when an error produced it.
             state = 3
 
     msg = "RPKI Validation State for {} via AS{} is {}".format(prefix, asn, RPKI_NAME_MAP[state])
     if cached is not None:
         msg += " [CACHED]"
-
     log.debug(msg)
     return state

--- a/hyperglass/external/tests/test_rpki.py
+++ b/hyperglass/external/tests/test_rpki.py
@@ -19,8 +19,8 @@ def test_rpki():
         result = rpki_state(prefix, asn)
         result_name = RPKI_NAME_MAP.get(result, "No Name")
         expected_name = RPKI_NAME_MAP.get(expected, "No Name")
-        assert result == expected, (
-            "RPKI State for '{}' via AS{!s} '{}' ({}) instead of '{}' ({})".format(
-                prefix, asn, result, result_name, expected, expected_name
-            )
+        assert (
+            result == expected
+        ), "RPKI State for '{}' via AS{!s} '{}' ({}) instead of '{}' ({})".format(
+            prefix, asn, result, result_name, expected, expected_name
         )

--- a/hyperglass/models/config/structured.py
+++ b/hyperglass/models/config/structured.py
@@ -3,11 +3,15 @@
 # Standard Library
 import typing as t
 
+# Third Party
+from pydantic import model_validator
+
 # Local
 from ..main import HyperglassModel
 
 StructuredCommunityMode = t.Literal["permit", "deny"]
 StructuredRPKIMode = t.Literal["router", "external"]
+StructuredRPKIBackend = t.Literal["cloudflare", "routinator"]
 
 
 class StructuredCommunities(HyperglassModel):
@@ -21,6 +25,17 @@ class StructuredRpki(HyperglassModel):
     """Control structured data response for RPKI state."""
 
     mode: StructuredRPKIMode = "router"
+    backend: StructuredRPKIBackend = "cloudflare"
+    rpki_server_url: str = ""
+
+    @model_validator(mode="after")
+    def validate_routinator_url(self) -> "StructuredRpki":
+        """Require a server URL when the routinator backend is selected."""
+        if self.backend == "routinator" and not self.rpki_server_url:
+            raise ValueError(
+                "structured.rpki.rpki_server_url is required when backend is 'routinator'"
+            )
+        return self
 
 
 class Structured(HyperglassModel):

--- a/hyperglass/models/data/bgp_route.py
+++ b/hyperglass/models/data/bgp_route.py
@@ -80,10 +80,9 @@ class BGPRoute(HyperglassModel):
             return value
 
         if structured.rpki.mode == "external":
-            # If external validation is enabled, validate the prefix
-            # & asn with Cloudflare's RPKI API.
+            # If external validation is enabled, validate the prefix & asn
+            # with the configured RPKI backend.
             as_path = info.data.get("as_path", [])
-
             if len(as_path) == 0:
                 # If the AS_PATH length is 0, i.e. for an internal route,
                 # return RPKI Unknown state.
@@ -91,14 +90,19 @@ class BGPRoute(HyperglassModel):
             # Get last ASN in path
             asn = as_path[-1]
 
-        try:
-            net = ip_network(info.data["prefix"])
-        except ValueError:
-            return 3
+            try:
+                net = ip_network(info.data["prefix"])
+            except ValueError:
+                return 3
 
-        # Only do external RPKI lookups for global prefixes.
-        if net.is_global:
-            return rpki_state(prefix=info.data["prefix"], asn=asn)
+            # Only do external RPKI lookups for global prefixes.
+            if net.is_global:
+                return rpki_state(
+                    prefix=info.data["prefix"],
+                    asn=asn,
+                    backend=structured.rpki.backend,
+                    rpki_server_url=structured.rpki.rpki_server_url,
+                )
 
         return value
 


### PR DESCRIPTION
## Summary
Adds a pluggable external RPKI validation backend. Alongside the existing Cloudflare GraphQL validator, a new `routinator` backend queries the `/validity` HTTP API of a self-hosted [Routinator](https://routinator.docs.nlnetlabs.nl/) instance. The RPKI state map is broadened to accept lower-case / hyphenated state names.

## Config
```yaml
structured:
  rpki:
    mode: external
    backend: routinator   # or "cloudflare" (default)
    rpki_server_url: "http://routinator.example.net:8323"   # required for routinator
```
- Reuses the existing `httpx` dependency (no new deps); `rpki_server_url` is validated as required when `backend: routinator`.
- Docs updated in `structured-output.mdx`.

---
**Stacked series (2/10).** Builds on `pr/state-init-retry`; until that merges, this diff also includes its commit.
