### PR TITLE
feat(huawei): structured BGP route output (4/10)

### DIFF
--- a/docs/pages/configuration/config/structured-output.mdx
+++ b/docs/pages/configuration/config/structured-output.mdx
@@ -4,19 +4,25 @@ Devices that support responding to a query with structured or easily parsable da
 
 -   Arista EOS
 -   Juniper Junos
+-   Huawei VRP
 
 When structured output is available, hyperglass checks the RPKI state of each BGP prefix returned using one of two methods:
 
 1. From the router's perspective
-2. From the perspective of [Cloudflare's RPKI Service](https://rpki.cloudflare.com/)
+2. From an external validator — either [Cloudflare's RPKI Service](https://rpki.cloudflare.com/) (the default) or a self-hosted [Routinator](https://routinator.docs.nlnetlabs.nl/) instance
+
+When `structured.rpki.mode` is `external`, the `structured.rpki.backend` field selects which validator to query. The `cloudflare` backend uses Cloudflare's GraphQL API; the `routinator` backend queries the `/validity` HTTP API of a Routinator instance at `structured.rpki.rpki_server_url`.
 
 Additionally, hyperglass provides the ability to control which BGP communities are shown to the end user.
 
 | Parameter                      | Type            | Default Value | Description                                                                                                                   |
 | :----------------------------- | :-------------- | :------------ | :---------------------------------------------------------------------------------------------------------------------------- |
-| `structured.rpki.mode`         | String          | router        | Use `router` to use the router's view of the RPKI state (1 above), or `external` to use Cloudflare's view (2 above).          |
-| `structured.communities.mode`  | String          | deny          | Use `deny` to deny any communities listed in `structured.communities.items`, or `permit` to _only_ permit communities listed. |
-| `structured.communities.items` | List of Strings |               | List of communities to match.                                                                                                 |
+| `structured.rpki.mode`         | String          | router        | Use `router` to use the router's view of the RPKI state (1 above), or `external` to use an external validator (2 above).      |
+| `structured.rpki.backend`      | String          | cloudflare    | When `mode` is `external`, the validator to use: `cloudflare` or `routinator`.                                               |
+| `structured.rpki.rpki_server_url` | String       |               | Base URL of the Routinator instance. **Required** when `backend` is `routinator` (e.g. `http://routinator.example.net:8323`). |
+| `structured.communities.mode`  | String          | deny          | `deny` hides communities listed in `items`; `permit` shows _only_ those listed; `name` shows all communities and appends a friendly label to any listed in `names`. |
+| `structured.communities.items` | List of Strings |               | List of communities to match (used by `deny`/`permit`).                                                                       |
+| `structured.communities.names` | Map of String→String |          | Map of community → friendly name, used by `name` mode. At least one entry is required when `mode` is `name`.                   |
 
 ### RPKI Examples
 
@@ -28,12 +34,23 @@ structured:
         mode: router
 ```
 
-#### Show RPKI State from a Public/External Perspective
+#### Show RPKI State from a Public/External Perspective (Cloudflare)
 
-```yaml filename="config.yaml" copy {2}
+```yaml filename="config.yaml" copy {2-3}
 structured:
     rpki:
         mode: external
+        backend: cloudflare
+```
+
+#### Validate RPKI State Against a Self-Hosted Routinator
+
+```yaml filename="config.yaml" copy {2-5}
+structured:
+    rpki:
+        mode: external
+        backend: routinator
+        rpki_server_url: "http://routinator.example.net:8323"
 ```
 
 ### Community Filtering Examples
@@ -58,4 +75,17 @@ structured:
         items:
             - "^65000:.*$" # permit any communities starting with 65000, but no others.
             - "1234:1" # permit only the 1234:1 community.
+```
+
+#### Show Friendly Names Alongside Communities
+
+With `mode: name`, all communities are shown, and any community listed in `names` has its friendly label appended (rendered as `<community> (<name>)` in the UI).
+
+```yaml filename="config.yaml" {3-6}
+structured:
+    communities:
+        mode: name
+        names:
+            "65000:100": "Customer Route"
+            "65000:200": "Peer Route"
 ```

--- a/hyperglass/api/state.py
+++ b/hyperglass/api/state.py
@@ -1,27 +1,52 @@
 """hyperglass state dependencies."""
 
 # Standard Library
+import asyncio
 import typing as t
 
 # Project
-from hyperglass.state import use_state
+from hyperglass.state import HyperglassState, use_state
+from hyperglass.exceptions.private import StateError
+
+
+def _is_retryable(attr: t.Optional[str]) -> bool:
+    """Whether a StateError for this attr is a transient (not-yet-populated) error.
+
+    A request can arrive before the Redis-backed state is populated on startup,
+    which surfaces as a StateError. Referencing an attribute that does not exist
+    on HyperglassState is a permanent programming error and must not be retried.
+    """
+    return attr is None or attr in ("cache", "redis") or attr in HyperglassState.properties()
+
+
+async def _get_state_with_retry(
+    attr: t.Optional[str] = None, max_retries: int = 5, retry_delay: float = 0.5
+) -> t.Any:
+    """Get hyperglass state, retrying transient startup StateErrors."""
+    for attempt in range(1, max_retries + 1):
+        try:
+            return use_state(attr)
+        except StateError:
+            if not _is_retryable(attr) or attempt == max_retries:
+                raise
+            await asyncio.sleep(retry_delay)
 
 
 async def get_state(attr: t.Optional[str] = None):
     """Get hyperglass state as a FastAPI dependency."""
-    return use_state(attr)
+    return await _get_state_with_retry(attr)
 
 
 async def get_params():
     """Get hyperglass params as FastAPI dependency."""
-    return use_state("params")
+    return await _get_state_with_retry("params")
 
 
 async def get_devices():
     """Get hyperglass devices as FastAPI dependency."""
-    return use_state("devices")
+    return await _get_state_with_retry("devices")
 
 
 async def get_ui_params():
     """Get hyperglass ui_params as FastAPI dependency."""
-    return use_state("ui_params")
+    return await _get_state_with_retry("ui_params")

--- a/hyperglass/constants.py
+++ b/hyperglass/constants.py
@@ -19,7 +19,7 @@ TARGET_FORMAT_SPACE = ("huawei", "huawei_vrpv8")
 
 TARGET_JUNIPER_ASPATH = ("juniper", "juniper_junos")
 
-SUPPORTED_STRUCTURED_OUTPUT = ("frr", "juniper", "arista_eos")
+SUPPORTED_STRUCTURED_OUTPUT = ("frr", "juniper", "arista_eos", "huawei")
 
 CONFIG_EXTENSIONS = ("py", "yaml", "yml", "json", "toml")
 

--- a/hyperglass/defaults/directives/huawei.py
+++ b/hyperglass/defaults/directives/huawei.py
@@ -15,6 +15,9 @@ __all__ = (
     "Huawei_BGPRoute",
     "Huawei_Ping",
     "Huawei_Traceroute",
+    "HuaweiBGPRouteTable",
+    "HuaweiBGPASPathTable",
+    "HuaweiBGPCommunityTable",
 )
 
 NAME = "Huawei VRP"
@@ -36,7 +39,8 @@ Huawei_BGPRoute = BuiltinDirective(
         ),
     ],
     field=Text(description="IP Address, Prefix, or Hostname"),
-    plugins=["bgp_route_huawei"],
+    plugins=["bgp_route_huawei", "bgp_routestr_huawei"],
+    table_output="__hyperglass_huawei_bgp_route_table__",
     platforms=PLATFORMS,
 )
 
@@ -54,6 +58,7 @@ Huawei_BGPASPath = BuiltinDirective(
         )
     ],
     field=Text(description="AS Path Regular Expression"),
+    table_output="__hyperglass_huawei_bgp_aspath_table__",
     platforms=PLATFORMS,
 )
 
@@ -71,6 +76,7 @@ Huawei_BGPCommunity = BuiltinDirective(
         )
     ],
     field=Text(description="BGP Community String"),
+    table_output="__hyperglass_huawei_bgp_community_table__",
     platforms=PLATFORMS,
 )
 
@@ -109,5 +115,60 @@ Huawei_Traceroute = BuiltinDirective(
         ),
     ],
     field=Text(description="IP Address, Prefix, or Hostname"),
+    platforms=PLATFORMS,
+)
+
+# Table Output Directives
+
+HuaweiBGPRouteTable = BuiltinDirective(
+    id="__hyperglass_huawei_bgp_route_table__",
+    name="BGP Route",
+    rules=[
+        RuleWithIPv4(
+            condition="0.0.0.0/0",
+            action="permit",
+            command="display bgp routing-table {target} | no-more",
+        ),
+        RuleWithIPv6(
+            condition="::/0",
+            action="permit",
+            command="display bgp ipv6 routing-table {target} | no-more",
+        ),
+    ],
+    field=Text(description="IP Address, Prefix, or Hostname"),
+    platforms=PLATFORMS,
+)
+
+HuaweiBGPASPathTable = BuiltinDirective(
+    id="__hyperglass_huawei_bgp_aspath_table__",
+    name="BGP AS Path",
+    rules=[
+        RuleWithPattern(
+            condition="*",
+            action="permit",
+            commands=[
+                'display bgp routing-table regular-expression "{target}"',
+                'display bgp ipv6 routing-table regular-expression "{target}"',
+            ],
+        )
+    ],
+    field=Text(description="AS Path Regular Expression"),
+    platforms=PLATFORMS,
+)
+
+HuaweiBGPCommunityTable = BuiltinDirective(
+    id="__hyperglass_huawei_bgp_community_table__",
+    name="BGP Community",
+    rules=[
+        RuleWithPattern(
+            condition="*",
+            action="permit",
+            commands=[
+                'display bgp routing-table community "{target}"',
+                'display bgp ipv6 routing-table community "{target}"',
+            ],
+        )
+    ],
+    field=Text(description="BGP Community String"),
     platforms=PLATFORMS,
 )

--- a/hyperglass/external/rpki.py
+++ b/hyperglass/external/rpki.py
@@ -3,57 +3,83 @@
 # Standard Library
 import typing as t
 
+# Third Party
+import httpx
+
 # Project
 from hyperglass.log import log
 from hyperglass.state import use_state
 from hyperglass.external._base import BaseExternal
 
 if t.TYPE_CHECKING:
-    # Standard Library
     from ipaddress import IPv4Address, IPv6Address
 
-RPKI_STATE_MAP = {"Invalid": 0, "Valid": 1, "NotFound": 2, "DEFAULT": 3}
-RPKI_NAME_MAP = {v: k for k, v in RPKI_STATE_MAP.items()}
+# Maps normalized (lower-case, separators stripped) backend state names to the
+# integer states hyperglass uses internally.
+RPKI_STATE_MAP = {
+    "invalid": 0,
+    "valid": 1,
+    "notfound": 2,
+    "unknown": 2,
+    "default": 3,
+}
+# Canonical integer -> display name, kept stable for logging.
+RPKI_NAME_MAP = {0: "Invalid", 1: "Valid", 2: "NotFound", 3: "DEFAULT"}
 CACHE_KEY = "hyperglass.external.rpki"
 
 
-def rpki_state(prefix: t.Union["IPv4Address", "IPv6Address", str], asn: t.Union[int, str]) -> int:
+def _normalize_state(value: str) -> int:
+    """Normalize a backend RPKI state string to an internal integer state."""
+    key = str(value).strip().lower().replace("-", "").replace("_", "")
+    return RPKI_STATE_MAP.get(key, 3)
+
+
+def rpki_state(
+    prefix: t.Union["IPv4Address", "IPv6Address", str],
+    asn: t.Union[int, str],
+    backend: str = "cloudflare",
+    rpki_server_url: str = "",
+) -> int:
     """Get RPKI state and map to expected integer."""
     _log = log.bind(prefix=prefix, asn=asn)
     _log.debug("Validating RPKI State")
 
     cache = use_state("cache")
-
     state = 3
     ro = f"{prefix!s}@{asn!s}"
 
     cached = cache.get_map(CACHE_KEY, ro)
-
     if cached is not None:
         state = cached
     else:
-        ql = 'query GetValidation {{ validation(prefix: "{}", asn: {}) {{ state }} }}'
-        query = ql.format(prefix, asn)
-        _log.bind(query=query).debug("Cloudflare RPKI GraphQL Query")
         try:
-            with BaseExternal(base_url="https://rpki.cloudflare.com") as client:
-                response = client._post("/api/graphql", data={"query": query})
-            try:
+            if backend == "cloudflare":
+                ql = 'query GetValidation {{ validation(prefix: "{}", asn: {}) {{ state }} }}'
+                query = ql.format(prefix, asn)
+                _log.bind(query=query).debug("Cloudflare RPKI GraphQL Query")
+                with BaseExternal(base_url="https://rpki.cloudflare.com") as client:
+                    response = client._post("/api/graphql", data={"query": query})
                 validation_state = response["data"]["validation"]["state"]
-            except KeyError as missing:
-                _log.error("Response from Cloudflare missing key '{}': {!r}", missing, response)
-                validation_state = 3
+            elif backend == "routinator":
+                url = f"{rpki_server_url.rstrip('/')}/validity"
+                _log.bind(url=url).debug("Routinator RPKI HTTP Query")
+                response = httpx.get(
+                    url, params={"asn": str(asn), "prefix": str(prefix)}, timeout=5
+                )
+                response.raise_for_status()
+                data = response.json()
+                validation_state = data["validated_route"]["validity"]["state"]
+            else:
+                raise ValueError(f"Unknown RPKI backend: {backend}")
 
-            state = RPKI_STATE_MAP[validation_state]
+            state = _normalize_state(validation_state)
             cache.set_map_item(CACHE_KEY, ro, state)
         except Exception as err:
             log.error(err)
-            # Don't cache the state when an error produced it.
             state = 3
 
     msg = "RPKI Validation State for {} via AS{} is {}".format(prefix, asn, RPKI_NAME_MAP[state])
     if cached is not None:
         msg += " [CACHED]"
-
     log.debug(msg)
     return state

--- a/hyperglass/external/tests/test_rpki.py
+++ b/hyperglass/external/tests/test_rpki.py
@@ -19,8 +19,8 @@ def test_rpki():
         result = rpki_state(prefix, asn)
         result_name = RPKI_NAME_MAP.get(result, "No Name")
         expected_name = RPKI_NAME_MAP.get(expected, "No Name")
-        assert result == expected, (
-            "RPKI State for '{}' via AS{!s} '{}' ({}) instead of '{}' ({})".format(
-                prefix, asn, result, result_name, expected, expected_name
-            )
+        assert (
+            result == expected
+        ), "RPKI State for '{}' via AS{!s} '{}' ({}) instead of '{}' ({})".format(
+            prefix, asn, result, result_name, expected, expected_name
         )

--- a/hyperglass/models/config/structured.py
+++ b/hyperglass/models/config/structured.py
@@ -3,11 +3,15 @@
 # Standard Library
 import typing as t
 
+# Third Party
+from pydantic import ValidationInfo, field_validator, model_validator
+
 # Local
 from ..main import HyperglassModel
 
-StructuredCommunityMode = t.Literal["permit", "deny"]
+StructuredCommunityMode = t.Literal["permit", "deny", "name"]
 StructuredRPKIMode = t.Literal["router", "external"]
+StructuredRPKIBackend = t.Literal["cloudflare", "routinator"]
 
 
 class StructuredCommunities(HyperglassModel):
@@ -15,12 +19,34 @@ class StructuredCommunities(HyperglassModel):
 
     mode: StructuredCommunityMode = "deny"
     items: t.List[str] = []
+    names: t.Dict[str, str] = {}
+
+    @field_validator("names")
+    def validate_names(cls, value: t.Dict[str, str], info: ValidationInfo) -> t.Dict[str, str]:
+        """Require at least one community mapping when mode is 'name'."""
+        if info.data and info.data.get("mode") == "name" and not value:
+            raise ValueError(
+                "When using mode 'name', at least one community mapping must be "
+                "provided in 'names'"
+            )
+        return value
 
 
 class StructuredRpki(HyperglassModel):
     """Control structured data response for RPKI state."""
 
     mode: StructuredRPKIMode = "router"
+    backend: StructuredRPKIBackend = "cloudflare"
+    rpki_server_url: str = ""
+
+    @model_validator(mode="after")
+    def validate_routinator_url(self) -> "StructuredRpki":
+        """Require a server URL when the routinator backend is selected."""
+        if self.backend == "routinator" and not self.rpki_server_url:
+            raise ValueError(
+                "structured.rpki.rpki_server_url is required when backend is 'routinator'"
+            )
+        return self
 
 
 class Structured(HyperglassModel):

--- a/hyperglass/models/data/bgp_route.py
+++ b/hyperglass/models/data/bgp_route.py
@@ -42,6 +42,7 @@ class BGPRoute(HyperglassModel):
         Actions:
             permit: only permit matches
             deny: only deny matches
+            name: append friendly names to matching communities
         """
 
         (structured := use_state("params").structured)
@@ -64,6 +65,15 @@ class BGPRoute(HyperglassModel):
                     break
             return valid
 
+        def _name(comm):
+            """Append a friendly name to a community when one is mapped."""
+            if comm in structured.communities.names:
+                return f"{comm},{structured.communities.names[comm]}"
+            return comm
+
+        if structured.communities.mode == "name":
+            return [_name(c) for c in value]
+
         func_map = {"permit": _permit, "deny": _deny}
         func = func_map[structured.communities.mode]
 
@@ -80,10 +90,9 @@ class BGPRoute(HyperglassModel):
             return value
 
         if structured.rpki.mode == "external":
-            # If external validation is enabled, validate the prefix
-            # & asn with Cloudflare's RPKI API.
+            # If external validation is enabled, validate the prefix & asn
+            # with the configured RPKI backend.
             as_path = info.data.get("as_path", [])
-
             if len(as_path) == 0:
                 # If the AS_PATH length is 0, i.e. for an internal route,
                 # return RPKI Unknown state.
@@ -91,14 +100,19 @@ class BGPRoute(HyperglassModel):
             # Get last ASN in path
             asn = as_path[-1]
 
-        try:
-            net = ip_network(info.data["prefix"])
-        except ValueError:
-            return 3
+            try:
+                net = ip_network(info.data["prefix"])
+            except ValueError:
+                return 3
 
-        # Only do external RPKI lookups for global prefixes.
-        if net.is_global:
-            return rpki_state(prefix=info.data["prefix"], asn=asn)
+            # Only do external RPKI lookups for global prefixes.
+            if net.is_global:
+                return rpki_state(
+                    prefix=info.data["prefix"],
+                    asn=asn,
+                    backend=structured.rpki.backend,
+                    rpki_server_url=structured.rpki.rpki_server_url,
+                )
 
         return value
 

--- a/hyperglass/models/parsing/huawei.py
+++ b/hyperglass/models/parsing/huawei.py
@@ -1,0 +1,394 @@
+"""Parser for Huawei VRP."""
+
+# Standard Library
+import re
+import typing as t
+
+# Third Party
+from pydantic import ConfigDict, field_validator, model_validator
+
+# Project
+from hyperglass.log import log
+from hyperglass.models.data.bgp_route import BGPRoute, BGPRouteTable
+
+# Local
+from ..main import HyperglassModel
+
+RPKI_STATE_MAP = {
+    "invalid": 0,
+    "valid": 1,
+    "unknown": 2,
+    "unverified": 3,
+}
+
+
+def remove_prefix(text: str, prefix: str) -> str:
+    """Remove prefix from text if it exists."""
+    if text.startswith(prefix):
+        return text[len(prefix) :]
+    return text
+
+
+class HuaweiBase(HyperglassModel, extra="ignore"):
+    """Base Huawei model."""
+
+    def __init__(self, **kwargs: t.Any) -> None:
+        """Initialize Huawei model."""
+        super().__init__(**kwargs)
+
+
+class HuaweiPaths(HuaweiBase):
+    """BGP paths information."""
+
+    available: int = 0
+    best: int = 0
+    select: int = 0
+    best_external: int = 0
+    add_path: int = 0
+
+
+class HuaweiRouteEntry(HuaweiBase):
+    """Parse Huawei route entry data."""
+
+    model_config = ConfigDict(validate_assignment=False)
+
+    prefix: str
+    from_addr: str = ""
+    duration: int = 0
+    direct_out_interface: str = ""
+    original_next_hop: str = ""
+    relay_ip_next_hop: str = ""
+    relay_ip_out_interface: str = ""
+    qos: str = ""
+    communities: t.List[str] = []
+    large_communities: t.List[str] = []
+    ext_communities: t.List[str] = []
+    as_path: t.List[int] = []
+    origin: str = ""
+    metric: int = 0  # MED
+    local_preference: int = 100
+    preference_value: int = 0
+    is_valid: bool = False
+    is_external: bool = False
+    is_backup: bool = False
+    is_best: bool = False
+    is_selected: bool = False
+    preference: int = 0
+
+    @property
+    def next_hop(self) -> str:
+        """Get next hop (original or relay IP)."""
+        return self.original_next_hop or self.relay_ip_next_hop
+
+    @property
+    def age(self) -> str:
+        """Get age as string."""
+        return str(self.duration)
+
+    @property
+    def weight(self) -> int:
+        """Get weight (preference)."""
+        return self.preference
+
+    @property
+    def med(self) -> int:
+        """Get MED (metric)."""
+        return self.metric
+
+    @property
+    def active(self) -> bool:
+        """Check if route is active (best or selected)."""
+        return self.is_best or self.is_selected
+
+    @property
+    def all_communities(self) -> t.List[str]:
+        """Get all communities combined."""
+        return self.communities + self.large_communities + self.ext_communities
+
+    @property
+    def source_as(self) -> int:
+        """Get source AS from AS path (first ASN in the path)."""
+        return self.as_path[0] if self.as_path else 0
+
+    @property
+    def source_rid(self) -> str:
+        """Get source router ID."""
+        return ""
+
+    @property
+    def peer_rid(self) -> str:
+        """Get peer router ID."""
+        return self.from_addr
+
+
+def _extract_paths(line: str) -> HuaweiPaths:
+    """Extract paths information from line like 'Paths: 3 available, 1 best, 1 select, 0 best-external, 0 add-path'."""
+    paths_data = {
+        "available": 0,
+        "best": 0,
+        "select": 0,
+        "best_external": 0,
+        "add_path": 0,
+    }
+
+    try:
+        values = remove_prefix(line.strip(), "Paths:").strip().split(",")
+        for value in values:
+            parts = value.strip().split(" ")
+            if len(parts) >= 2:
+                count = int(parts[0])
+                name = parts[1].replace("-", "_")  # Convert best-external to best_external
+                if name in paths_data:
+                    paths_data[name] = count
+    except (ValueError, IndexError):
+        log.warning(f"Failed to parse paths line: {line}")
+
+    return HuaweiPaths(**paths_data)
+
+
+def _extract_route_entries(lines: t.List[str]) -> t.List[HuaweiRouteEntry]:
+    """Extract route entries from lines."""
+    routes = []
+
+    # Split lines into route blocks using empty lines as separators
+    size = len(lines)
+    idx_list = [idx + 1 for idx, val in enumerate(lines) if val.strip() == ""]
+    entries = (
+        [
+            lines[i:j]
+            for i, j in zip([0] + idx_list, idx_list + ([size] if idx_list[-1] != size else []))
+        ]
+        if idx_list
+        else [lines]
+    )
+
+    for route_entry in entries:
+        if not route_entry:
+            continue
+
+        # Initialize route data
+        route_data = {
+            "prefix": "",
+            "from_addr": "",
+            "duration": 0,
+            "direct_out_interface": "",
+            "original_next_hop": "",
+            "relay_ip_next_hop": "",
+            "relay_ip_out_interface": "",
+            "qos": "",
+            "communities": [],
+            "large_communities": [],
+            "ext_communities": [],
+            "as_path": [],
+            "origin": "",
+            "metric": 0,
+            "local_preference": 100,
+            "preference_value": 0,
+            "is_valid": False,
+            "is_external": False,
+            "is_backup": False,
+            "is_best": False,
+            "is_selected": False,
+            "preference": 0,
+        }
+
+        for info in route_entry:
+            info = info.strip()
+            if not info:
+                continue
+
+            if info.startswith("BGP routing table entry information of"):
+                route_data["prefix"] = remove_prefix(
+                    info, "BGP routing table entry information of "
+                ).rstrip(":")
+            elif info.startswith("From:"):
+                route_data["from_addr"] = remove_prefix(info, "From: ").split(" (")[0]
+            elif info.startswith("Route Duration:"):
+                duration_str = remove_prefix(info, "Route Duration: ")
+                try:
+                    # Parse format like "84d11h53m07s"
+                    d_match = re.search(r"(\d+)d", duration_str)
+                    h_match = re.search(r"(\d+)h", duration_str)
+                    m_match = re.search(r"(\d+)m", duration_str)
+                    s_match = re.search(r"(\d+)s", duration_str)
+
+                    days = int(d_match.group(1)) if d_match else 0
+                    hours = int(h_match.group(1)) if h_match else 0
+                    minutes = int(m_match.group(1)) if m_match else 0
+                    seconds = int(s_match.group(1)) if s_match else 0
+
+                    route_data["duration"] = (
+                        days * 24 * 60 * 60 + hours * 60 * 60 + minutes * 60 + seconds
+                    )
+                except:
+                    route_data["duration"] = 0
+            elif info.startswith("Direct Out-interface:"):
+                route_data["direct_out_interface"] = remove_prefix(info, "Direct Out-interface: ")
+            elif info.startswith("Original nexthop:"):
+                route_data["original_next_hop"] = remove_prefix(info, "Original nexthop: ")
+            elif info.startswith("Relay IP Nexthop:"):
+                route_data["relay_ip_next_hop"] = remove_prefix(info, "Relay IP Nexthop: ")
+            elif info.startswith("Relay IP Out-Interface:"):
+                route_data["relay_ip_out_interface"] = remove_prefix(
+                    info, "Relay IP Out-Interface: "
+                )
+            elif info.startswith("Qos information :"):
+                route_data["qos"] = remove_prefix(info, "Qos information : ")
+            elif info.startswith("Community:"):
+                communities_str = remove_prefix(info, "Community: ")
+                if communities_str and communities_str.lower() != "none":
+                    communities = [
+                        c.strip().replace("<", "").replace(">", "")
+                        for c in communities_str.split(", ")
+                    ]
+                    route_data["communities"] = [c for c in communities if c]
+            elif info.startswith("Large-Community:"):
+                large_communities_str = remove_prefix(info, "Large-Community: ")
+                if large_communities_str and large_communities_str.lower() != "none":
+                    large_communities = [
+                        c.strip().replace("<", "").replace(">", "")
+                        for c in large_communities_str.split(", ")
+                    ]
+                    route_data["large_communities"] = [c for c in large_communities if c]
+            elif info.startswith("Ext-Community:"):
+                ext_communities_str = remove_prefix(info, "Ext-Community: ")
+                if ext_communities_str and ext_communities_str.lower() != "none":
+                    ext_communities = [
+                        c.strip().replace("<", "").replace(">", "")
+                        for c in ext_communities_str.split(", ")
+                    ]
+                    route_data["ext_communities"] = [c for c in ext_communities if c]
+            elif info.startswith("AS-path"):
+                values = info.split(",")
+                for v in values:
+                    v = v.strip()
+                    if v.startswith("AS-path"):
+                        as_path_str = remove_prefix(v, "AS-path ")
+                        try:
+                            route_data["as_path"] = [
+                                int(a) for a in as_path_str.split() if a.isdigit()
+                            ]
+                        except ValueError:
+                            route_data["as_path"] = []
+                    elif v.startswith("origin"):
+                        route_data["origin"] = remove_prefix(v, "origin ")
+                    elif v.startswith("MED"):
+                        try:
+                            route_data["metric"] = int(remove_prefix(v, "MED "))
+                        except ValueError:
+                            route_data["metric"] = 0
+                    elif v.startswith("localpref"):
+                        try:
+                            route_data["local_preference"] = int(remove_prefix(v, "localpref "))
+                        except ValueError:
+                            route_data["local_preference"] = 100
+                    elif v.startswith("pref-val"):
+                        try:
+                            route_data["preference_value"] = int(remove_prefix(v, "pref-val "))
+                        except ValueError:
+                            route_data["preference_value"] = 0
+                    elif v.startswith("pre "):
+                        try:
+                            route_data["preference"] = int(remove_prefix(v, "pre "))
+                        except ValueError:
+                            route_data["preference"] = 0
+                    elif v.strip() == "valid":
+                        route_data["is_valid"] = True
+                    elif v.strip() == "external":
+                        route_data["is_external"] = True
+                    elif v.strip() == "backup":
+                        route_data["is_backup"] = True
+                    elif v.strip() == "best":
+                        route_data["is_best"] = True
+                    elif v.strip() == "select":
+                        route_data["is_selected"] = True
+
+        # Only add route if we have a valid prefix
+        if route_data["prefix"]:
+            try:
+                route = HuaweiRouteEntry(**route_data)
+                routes.append(route)
+            except Exception as e:
+                log.warning(
+                    "Failed to create route entry for prefix {}: {}",
+                    route_data.get("prefix", "unknown"),
+                    e,
+                )
+                continue
+
+    return routes
+
+
+class HuaweiBGPRouteTable(BGPRouteTable):
+    """Canonical Huawei BGP Route Table."""
+
+    # No custom __init__ needed; inherit from BGPRouteTable (which should be a Pydantic model)
+
+
+class HuaweiBGPTable(HuaweiBase):
+    """Validation model for Huawei BGP table data."""
+
+    local_router_id: str = ""
+    local_as_number: int = 0
+    paths: HuaweiPaths = HuaweiPaths()
+    routes: t.List[HuaweiRouteEntry] = []
+
+    @classmethod
+    def parse_text(cls, text: str) -> "HuaweiBGPTable":
+        """Parse Huawei BGP text output."""
+        _log = log.bind(parser="HuaweiBGPTable")
+
+        instance = cls()
+
+        lines = text.split("\n")
+
+        # Extract general information
+        for line in lines:
+            if "BGP local router ID" in line:
+                instance.local_router_id = remove_prefix(line, "BGP local router ID : ").strip()
+            elif "Local AS number" in line:
+                try:
+                    instance.local_as_number = int(
+                        remove_prefix(line, "Local AS number : ").strip()
+                    )
+                except ValueError:
+                    instance.local_as_number = 0
+            elif line.strip().startswith("Paths:"):
+                instance.paths = _extract_paths(line)
+
+        # Extract route entries
+        instance.routes = _extract_route_entries(lines)
+
+        _log.debug(f"Parsed {len(instance.routes)} Huawei routes")
+        return instance
+
+    def bgp_table(self) -> BGPRouteTable:
+        """Convert to standard BGP table format."""
+        routes = []
+
+        for route in self.routes:
+            route_data = {
+                "prefix": route.prefix,
+                "active": route.active,
+                "age": route.age,
+                "weight": route.weight,
+                "med": route.med,
+                "local_preference": route.local_preference,
+                "as_path": route.as_path,
+                "communities": route.all_communities,
+                "next_hop": route.next_hop,
+                "source_as": route.source_as,
+                "source_rid": route.source_rid,
+                "peer_rid": route.peer_rid,
+                "rpki_state": (
+                    RPKI_STATE_MAP["valid"] if route.is_valid else RPKI_STATE_MAP["unknown"]
+                ),
+            }
+            routes.append(BGPRoute(**route_data))
+
+        return HuaweiBGPRouteTable(
+            vrf="default",
+            count=len(routes),
+            routes=routes,
+            winning_weight="high",
+        )

--- a/hyperglass/plugins/_builtin/__init__.py
+++ b/hyperglass/plugins/_builtin/__init__.py
@@ -5,6 +5,7 @@ from .bgp_route_frr import BGPRoutePluginFrr
 from .remove_command import RemoveCommand
 from .bgp_route_arista import BGPRoutePluginArista
 from .bgp_route_huawei import BGPRoutePluginHuawei
+from .bgp_routestr_huawei import BGPSTRRoutePluginHuawei
 from .bgp_route_juniper import BGPRoutePluginJuniper
 from .mikrotik_garbage_output import MikrotikGarbageOutput
 
@@ -13,6 +14,7 @@ __all__ = (
     "BGPRoutePluginFrr",
     "BGPRoutePluginJuniper",
     "BGPRoutePluginHuawei",
+    "BGPSTRRoutePluginHuawei",
     "MikrotikGarbageOutput",
     "RemoveCommand",
 )

--- a/hyperglass/plugins/_builtin/bgp_route_huawei.py
+++ b/hyperglass/plugins/_builtin/bgp_route_huawei.py
@@ -21,7 +21,10 @@ class BGPRoutePluginHuawei(InputPlugin):
         "huawei",
         "huawei_vrpv8",
     )
-    directives: t.Sequence[str] = ("__hyperglass_huawei_bgp_route__",)
+    directives: t.Sequence[str] = (
+        "__hyperglass_huawei_bgp_route__",
+        "__hyperglass_huawei_bgp_route_table__",
+    )
     """
     Huawei BGP Route Input Plugin
 
@@ -33,15 +36,25 @@ class BGPRoutePluginHuawei(InputPlugin):
     def transform(self, query: "Query") -> InputPluginTransformReturn:
         target = query.query_target
 
-        if not target or not isinstance(target, list) or len(target) == 0:
+        if not target:
             return None
 
-        target = target[0].strip()
+        if isinstance(target, list):
+            if len(target) == 0:
+                return None
+            target = target[0].strip()
+        elif isinstance(target, str):
+            target = target.strip()
+        else:
+            return None
 
         # Check for the / in the query target
         if target.find("/") == -1:
             return target
 
-        target_network = ip_network(target)
-
-        return f"{target_network.network_address!s} {target_network.prefixlen!s}"
+        try:
+            target_network = ip_network(target)
+            return f"{target_network.network_address!s} {target_network.prefixlen!s}"
+        except ValueError:
+            # Return the target unchanged if it isn't a valid network
+            return target

--- a/hyperglass/plugins/_builtin/bgp_routestr_huawei.py
+++ b/hyperglass/plugins/_builtin/bgp_routestr_huawei.py
@@ -1,0 +1,80 @@
+"""Coerce a Huawei route table in text format to a standard BGP Table structure."""
+
+# Standard Library
+import re
+from typing import TYPE_CHECKING, List, Sequence
+
+# Third Party
+from pydantic import PrivateAttr, ValidationError
+
+# Project
+from hyperglass.log import log
+from hyperglass.exceptions.private import ParsingError
+from hyperglass.models.parsing.huawei import HuaweiBGPTable
+
+# Local
+from .._output import OutputPlugin
+
+if TYPE_CHECKING:
+    # Project
+    from hyperglass.models.data import OutputDataModel
+    from hyperglass.models.api.query import Query
+
+    # Local
+    from .._output import OutputType
+
+
+def parse_huawei(output: Sequence[str]) -> "OutputDataModel":
+    """Parse a Huawei BGP text response."""
+    result = None
+
+    _log = log.bind(plugin=BGPSTRRoutePluginHuawei.__name__)
+
+    for response in output:
+        try:
+            # Parse the text output using the Huawei parser
+            validated = HuaweiBGPTable.parse_text(response)
+            bgp_table = validated.bgp_table()
+
+            if result is None:
+                result = bgp_table
+            else:
+                result += bgp_table
+
+        except ValidationError as err:
+            _log.critical(err)
+            raise ParsingError(err) from err
+        except Exception as err:
+            _log.bind(error=str(err)).critical("Failed to parse Huawei BGP output")
+            raise ParsingError("Error parsing response data") from err
+
+    return result
+
+
+class BGPSTRRoutePluginHuawei(OutputPlugin):
+    """Coerce a Huawei route table in text format to a standard BGP Table structure."""
+
+    _hyperglass_builtin: bool = PrivateAttr(True)
+    platforms: Sequence[str] = ("huawei",)
+    directives: Sequence[str] = (
+        "__hyperglass_huawei_bgp_route_table__",
+        "__hyperglass_huawei_bgp_aspath_table__",
+        "__hyperglass_huawei_bgp_community_table__",
+    )
+
+    def process(self, *, output: "OutputType", query: "Query") -> "OutputType":
+        """Parse Huawei response if data is a string (and is therefore unparsed)."""
+        _log = log.bind(plugin=self.__class__.__name__)
+        _log.debug("Processing Huawei output with structured parser")
+
+        should_process = all(
+            (
+                isinstance(output, (list, tuple)),
+                query.device.platform in self.platforms,
+                query.device.structured_output is True,
+                query.device.has_directives(*self.directives),
+            )
+        )
+        if should_process:
+            return parse_huawei(output)
+        return output

--- a/hyperglass/plugins/tests/test_bgp_route_huawei.py
+++ b/hyperglass/plugins/tests/test_bgp_route_huawei.py
@@ -1,0 +1,75 @@
+"""Huawei VRP structured BGP route parsing tests."""
+
+# flake8: noqa
+# Standard Library
+import typing as t
+
+# Third Party
+import pytest
+
+# Project
+from hyperglass.state import use_state
+from hyperglass.models.config.params import Params
+from hyperglass.models.data.bgp_route import BGPRouteTable
+from hyperglass.models.parsing.huawei import HuaweiBGPTable
+
+if t.TYPE_CHECKING:
+    from hyperglass.state import HyperglassState
+
+# Representative `display bgp routing-table <prefix>` detail output: one best/
+# selected (active) route and one valid-but-not-best route.
+SAMPLE = """
+ BGP local router ID : 192.0.2.1
+ Local AS number : 64500
+ Paths:   2 available, 1 best, 1 select
+
+ BGP routing table entry information of 203.0.113.0/24:
+ From: 198.51.100.1 (192.0.2.254)
+ Route Duration: 0d00h05m12s
+ Original nexthop: 198.51.100.1
+ Community: 64500:100, 64500:200
+ AS-path 64500 64501, origin igp, MED 0, localpref 100, pref-val 0, valid, external, best, select, pre 255
+
+ BGP routing table entry information of 203.0.113.128/25:
+ From: 198.51.100.2 (192.0.2.253)
+ Route Duration: 0d00h01m00s
+ Original nexthop: 198.51.100.2
+ AS-path 64500 64999, origin incomplete, MED 10, localpref 90, pref-val 0, valid, external, pre 255
+"""
+
+
+@pytest.fixture
+def params() -> t.Dict[str, t.Any]:
+    return {}
+
+
+@pytest.fixture
+def state(*, params: t.Dict[str, t.Any]) -> t.Generator["HyperglassState", None, None]:
+    """Initialize Redis-backed state with params for BGPRoute validation."""
+    _state = use_state()
+    _params = Params(**params)
+    with _state.cache.pipeline() as pipeline:
+        pipeline.set("params", _params)
+    yield _state
+    _state.clear()
+
+
+def test_huawei_bgp_route(state):
+    table = HuaweiBGPTable.parse_text(SAMPLE).bgp_table()
+
+    assert isinstance(table, BGPRouteTable), "Parsed result is not a BGPRouteTable"
+    assert table.count == 2, f"Expected 2 routes, got {table.count}"
+
+    by_prefix = {r.prefix: r for r in table.routes}
+    assert set(by_prefix) == {"203.0.113.0/24", "203.0.113.128/25"}
+
+    best = by_prefix["203.0.113.0/24"]
+    assert best.active is True, "best+select route should be active"
+    assert best.as_path == [64500, 64501], f"Bad as_path: {best.as_path}"
+    assert best.source_as == 64500, "source_as should be first ASN in path"
+    assert best.next_hop == "198.51.100.1"
+    assert "64500:100" in best.communities
+
+    other = by_prefix["203.0.113.128/25"]
+    assert other.active is False, "non-best route should not be active"
+    assert other.as_path == [64500, 64999]


### PR DESCRIPTION
## Summary
Adds structured BGP route output for **Huawei VRP**, parsing `display bgp routing-table` detail (routes, AS-path, communities, RPKI/origin) into the standard structured table, and registers `huawei` as a structured-capable platform.

- New parser `models/parsing/huawei.py` + `bgp_routestr_huawei` output plugin; hardens the existing `bgp_route_huawei` input transform against non-list/invalid targets.
- Includes a parser unit test.
- The original Huawei parser work is by @CarlosSuporteISP (credited as commit co-author).

---
**Stacked series (4/10).** Builds on `pr/bgp-community-names`.

### Addresses
Adds structured Huawei BGP-route parsing and hardens the input transform (accepts a string *or* list target and tolerates non-prefix input). Intended to resolve the following upstream issues — confirmation on the affected hardware would be appreciated:
- #315 — *Impossible to use command "BGP Route" with Huawei NetEngine 8000*
- #187 — *Error in bgp_router query on Huawei*