### PR TITLE
feat(mikrotik): structured-output parsing base + validation fix (7/10)

### DIFF
--- a/docs/pages/configuration/config/structured-output.mdx
+++ b/docs/pages/configuration/config/structured-output.mdx
@@ -1,22 +1,41 @@
+import { Callout } from "nextra/components";
+
 ## Structured
 
 Devices that support responding to a query with structured or easily parsable data can have their response data placed into an easier to read table (or JSON, when using the REST API). Currently, the following platforms have structured data supported in hyperglass:
 
 -   Arista EOS
+-   FRRouting
+-   Huawei VRP
 -   Juniper Junos
+-   Mikrotik RouterOS/SwitchOS
 
 When structured output is available, hyperglass checks the RPKI state of each BGP prefix returned using one of two methods:
 
-1. From the router's perspective
-2. From the perspective of [Cloudflare's RPKI Service](https://rpki.cloudflare.com/)
+1. **From the router's perspective** - Uses the RPKI validation state as determined by the router itself
+2. **From an external RPKI validation service** - Queries an external service to determine RPKI state independently
+
+For external validation, hyperglass supports two backends:
+- **Cloudflare**: Uses [Cloudflare's public RPKI service](https://rpki.cloudflare.com/) via GraphQL API
+- **Routinator**: Connects to your own [Routinator](https://github.com/NLnetLabs/routinator) RPKI validator instance
 
 Additionally, hyperglass provides the ability to control which BGP communities are shown to the end user.
 
-| Parameter                      | Type            | Default Value | Description                                                                                                                   |
-| :----------------------------- | :-------------- | :------------ | :---------------------------------------------------------------------------------------------------------------------------- |
-| `structured.rpki.mode`         | String          | router        | Use `router` to use the router's view of the RPKI state (1 above), or `external` to use Cloudflare's view (2 above).          |
-| `structured.communities.mode`  | String          | deny          | Use `deny` to deny any communities listed in `structured.communities.items`, or `permit` to _only_ permit communities listed. |
-| `structured.communities.items` | List of Strings |               | List of communities to match.                                                                                                 |
+For devices with structured traceroute support (FRRouting, Huawei VRP, and MikroTik RouterOS), hyperglass can enhance the output with IP enrichment data including ASN information, organization names, country codes, and IXP detection using real-time lookups from BGP.tools.
+
+| Parameter                         | Type            | Default Value | Description                                                                                                                            |
+| :-------------------------------- | :-------------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------- |
+| `structured.rpki.mode`            | String          | router        | Use `router` to use the router's view of the RPKI state, or `external` to use an external validation service.                        |
+| `structured.rpki.backend`         | String          | cloudflare    | When using `external` mode, choose `cloudflare` or `routinator` as the validation backend.                                           |
+| `structured.rpki.rpki_server_url` | String          |               | When using `routinator` backend, specify the base URL of your Routinator server (e.g., `http://rpki.example.com:3323`).             |
+| `structured.communities.mode`     | String          | deny          | Use `deny` to deny any communities listed, `permit` to _only_ permit communities listed, or `name` to append friendly names.         |
+| `structured.communities.items`    | List of Strings |               | List of communities to match (used by `deny` and `permit` modes).                                                                     |
+| `structured.communities.names`    | Dict            |               | Dictionary mapping BGP community codes to friendly names (used by `name` mode).                                                       |
+| `structured.ip_enrichment.cache_timeout`    | Integer         | 604800        | **DEPRECATED:** No longer used with real-time BGP.tools lookups. Kept for backward compatibility only.                               |
+| `structured.ip_enrichment.enrich_traceroute`| Boolean         | false         | When `structured:` is present, enable IP enrichment of traceroute hops (ASN, org, IXP). This must be true for enrichment to run.   |
+| `structured.ip_enrichment.enrich_bgproute` | Boolean         | false         | When `structured:` is present, enable early ASN/org enrichment for BGP routes. When true, enrichment happens immediately on query response. When false, enrichment is lazy-loaded when viewing AS Path. |
+| `structured.enable_for_traceroute`| Boolean         | (when structured present) true | When `structured:` is present this controls whether the structured traceroute table output is shown. Set to false to force raw router output. |
+| `structured.enable_for_bgp_route`| Boolean         | (when structured present) true | When `structured:` is present this controls whether the structured BGP route table output is shown. Set to false to force raw router output. |
 
 ### RPKI Examples
 
@@ -28,13 +47,30 @@ structured:
         mode: router
 ```
 
-#### Show RPKI State from a Public/External Perspective
+#### Show RPKI State from Cloudflare's Public Service
 
-```yaml filename="config.yaml" copy {2}
+```yaml filename="config.yaml" copy {2-4}
 structured:
     rpki:
         mode: external
+        backend: cloudflare
 ```
+
+#### Show RPKI State from a Custom Routinator Server
+
+```yaml filename="config.yaml" copy {2-5}
+structured:
+    rpki:
+        mode: external
+        backend: routinator
+        rpki_server_url: "http://rpki.example.com:8080"
+```
+
+<Callout type="info" emoji="ℹ️">
+    **Routinator URL Format**
+    
+    The `rpki_server_url` should be the base URL of your Routinator HTTP web API endpoint. This is typically different from the RTR port (3323). The URL should not include the `/validity` path as hyperglass will append this automatically.
+</Callout>
 
 ### Community Filtering Examples
 
@@ -59,3 +95,167 @@ structured:
             - "^65000:.*$" # permit any communities starting with 65000, but no others.
             - "1234:1" # permit only the 1234:1 community.
 ```
+
+#### Append Friendly Names to Communities
+
+```yaml filename="config.yaml" {2-10}
+structured:
+    communities:
+        mode: name
+        names:
+            "65000:1000": "Upstream Any"
+            "65000:1001": "Upstream A (all locations)"
+            "65000:1101": "Upstream A Location 1"
+            "65000:1201": "Upstream A Location 2"
+            "65000:1002": "Upstream B (all locations)"
+            "65000:1102": "Upstream B Location 1"
+            "65000:2000": "IXP Any"
+```
+
+### IP Enrichment Examples
+
+<Callout type="info" emoji="ℹ️">
+    **IP Enrichment Requirements**
+    
+    IP enrichment is currently supported for traceroute outputs on supported platforms.
+    
+    The system uses real-time lookups from BGP.tools for maximum accuracy and reliability.
+</Callout>
+
+#### Enable IP Enrichment for Traceroute
+
+```yaml filename="config.yaml" copy {2-4}
+structured:
+    # Ensure `structured:` exists to enable structured output. By default the
+    # structured table output is enabled when this block is present. To disable
+    # the structured traceroute table, set `structured.enable_for_traceroute: false`.
+    ip_enrichment:
+        enrich_traceroute: true
+```
+
+#### Enable IP Enrichment
+
+```yaml filename="config.yaml" copy {2-4}
+structured:
+    ip_enrichment:
+        enrich_traceroute: true
+        # cache_timeout is deprecated - real-time lookups are used
+```
+
+#### Enable IP Enrichment for Traceroute
+
+```yaml filename="config.yaml" copy {2-3}
+structured:
+    ip_enrichment:
+        enrich_traceroute: true
+```
+
+<Callout type="warning" emoji="⚠️">
+    **Performance Considerations**
+    
+    - Initial cache loading may take 30-60 seconds on first startup
+    - Data is cached locally using pickle format for ultra-fast subsequent loads
+    - Cache files are stored in `/etc/hyperglass/ip_enrichment/`
+    - Minimum cache timeout is 24 hours (86400 seconds) to prevent excessive API usage
+</Callout>
+
+### Structured Traceroute Configuration
+
+<Callout type="info" emoji="ℹ️">
+    **Structured Traceroute Support**
+    
+    Structured traceroute with rich metadata is available for:
+    - **FRRouting**: Parses Unix-style traceroute output with load balancing and multi-path support
+    - **Huawei VRP**: Parses Unix-style traceroute output
+    - **MikroTik RouterOS/SwitchOS**: Parses multi-table format with statistics
+    
+    When IP enrichment is enabled, traceroute hops are enhanced with ASN numbers, organization names, country codes, prefixes, and IXP detection.
+</Callout>
+
+#### Complete Structured Traceroute Setup
+
+```yaml filename="config.yaml" copy {2-12}
+structured:
+    rpki:
+        mode: external
+        backend: routinator
+        rpki_server_url: "https://rpki.example.com"
+    communities:
+        mode: name
+        names:
+            "65000:1000": "Transit Routes"
+            "65000:2000": "Peer Routes"
+    ip_enrichment:
+        enrich_traceroute: true
+        # cache_timeout is deprecated - real-time lookups are used
+```
+
+#### Structured Traceroute with Cloudflare RPKI
+
+```yaml filename="config.yaml" copy {2-9}
+structured:
+    rpki:
+        mode: external
+        backend: cloudflare
+    ip_enrichment:
+        enrich_traceroute: true
+```
+
+#### Minimal Structured Traceroute (No IP Enrichment)
+
+```yaml filename="config.yaml" copy {2-4}
+structured:
+    ip_enrichment:
+        enrich_traceroute: false  # Traceroute will show basic hop info without ASN/org data
+        enrich_bgproute: true      # BGP routes will include ASN/org enrichment on query response
+```
+
+<Callout type="warning" emoji="⚠️">
+    **IP Enrichment Dependency**
+    
+    Without IP enrichment enabled:
+    - Traceroute hops will only show IP addresses and RTT values
+    - BGP next-hop IPs will not show ASN/organization tooltips
+    - No ASN organization names in copied BGP route text
+    - AS path visualization will be limited or unavailable
+    - IXP detection will not function
+    
+    For the full structured traceroute and BGP route experience with rich metadata, enable the appropriate enrichment settings.
+</Callout>
+
+### BGP Route Enrichment
+
+BGP route enrichment provides two modes for ASN and organization lookups:
+
+#### Early Enrichment (On-Query)
+When `enrich_bgproute: true`, enrichment happens immediately during query execution:
+- ✅ ASN names appear instantly in AS path entries
+- ✅ Next-hop IP tooltips show organization information
+- ✅ Copied text includes enriched data: `37468 (Organization) → 12956 (Organization)`
+- ⚠️ Adds a small delay to query execution for bulk lookups
+
+```yaml filename="config.yaml" copy {4}
+structured:
+    ip_enrichment:
+        enrich_bgproute: true
+```
+
+#### Lazy Enrichment (On-Demand)
+When `enrich_bgproute: false` (default), enrichment happens only when needed:
+- ✅ Faster initial query response
+- ✅ Organization names load when clicking "View AS Path" button or hovering
+- ✅ Reduces unnecessary lookups for partial queries
+- ⚠️ Organization names not included in copied text by default
+
+```yaml filename="config.yaml" copy {4}
+structured:
+    ip_enrichment:
+        enrich_bgproute: false
+```
+
+#### Next-Hop Enrichment
+
+Regardless of enrichment mode, next-hop IPs for BGP routes are always enriched with:
+- Peer ASN (if available)
+- Peer organization name (if available)
+- Hovering over a next-hop IP shows: `192.0.2.1 (ASN Organization)`

--- a/hyperglass/constants.py
+++ b/hyperglass/constants.py
@@ -19,7 +19,14 @@ TARGET_FORMAT_SPACE = ("huawei", "huawei_vrpv8")
 
 TARGET_JUNIPER_ASPATH = ("juniper", "juniper_junos")
 
-SUPPORTED_STRUCTURED_OUTPUT = ("frr", "juniper", "arista_eos")
+SUPPORTED_STRUCTURED_OUTPUT = (
+    "frr",
+    "juniper",
+    "arista_eos",
+    "huawei",
+    "mikrotik_routeros",
+    "mikrotik_switchos",
+)
 
 CONFIG_EXTENSIONS = ("py", "yaml", "yml", "json", "toml")
 

--- a/hyperglass/models/config/devices.py
+++ b/hyperglass/models/config/devices.py
@@ -247,10 +247,10 @@ class Device(HyperglassModelWithId, extra="allow"):
         if value is True:
             if info.data.get("platform") not in SUPPORTED_STRUCTURED_OUTPUT:
                 raise ConfigError(
-                    "The 'structured_output' field is set to 'true' on device '{}' with "
-                    + "platform '{}', which does not support structured output",
-                    info.data.get("name"),
-                    info.data.get("platform"),
+                    "The 'structured_output' field is set to 'true' on device '{d}' with "
+                    "platform '{p}', which does not support structured output",
+                    d=info.data.get("name"),
+                    p=info.data.get("platform"),
                 )
             return value
         if value is None and info.data.get("platform") in SUPPORTED_STRUCTURED_OUTPUT:

--- a/hyperglass/models/parsing/mikrotik.py
+++ b/hyperglass/models/parsing/mikrotik.py
@@ -1,0 +1,561 @@
+"""Parser for MikroTik RouterOS (ROS v6/v7) – structured in Huawei style."""
+
+# Standard Library
+import re
+import typing as t
+
+# Third Party
+from pydantic import ConfigDict
+
+# Project
+from hyperglass.log import log
+from hyperglass.settings import Settings
+from hyperglass.models.data.bgp_route import BGPRoute, BGPRouteTable  # Add BGPRoute import
+
+# Local
+from ..main import HyperglassModel
+
+RPKI_STATE_MAP = {
+    "invalid": 0,
+    "valid": 1,
+    "unknown": 2,
+    "unverified": 3,
+}
+
+
+def remove_prefix(text: str, prefix: str) -> str:
+    if text.startswith(prefix):
+        return text[len(prefix) :]
+    return text
+
+
+# Regex to find key=value pairs. The key can contain dots and hyphens.
+# The value can be quoted or a single word.
+TOKEN_RE = re.compile(r'([a-zA-Z0-9_.-]+)=(".*?"|\S+)')
+
+# Regex to find flags at the beginning of a line (e.g., "Ab   dst-address=...").
+# Include filtered/disabled/unreachable flags so those routes split into their own entries.
+FLAGS_RE = re.compile(r"^\s*([DXUuIAFfcmsroivmyH\+b]+)\s+")
+
+
+class MikrotikBase(HyperglassModel, extra="ignore"):
+    """Base model for MikroTik parsing models (ignores unknown fields)."""
+
+
+class MikrotikPaths(MikrotikBase):
+    available: int = 0
+    best: int = 0
+    select: int = 0
+    best_external: int = 0
+    add_path: int = 0
+
+
+class MikrotikRouteEntry(MikrotikBase):
+    """MikroTik Route Entry."""
+
+    model_config = ConfigDict(validate_assignment=False)
+
+    prefix: str
+    gateway: str = ""
+    distance: int = 0
+    scope: int = 0
+    target_scope: int = 0
+    as_path: t.List[int] = []
+    communities: t.List[str] = []
+    large_communities: t.List[str] = []
+    ext_communities: t.List[str] = []
+    local_preference: int = 100
+    metric: int = 0  # MED
+    origin: str = ""
+    belongs_to: str = ""  # BGP session identifier
+    is_active: bool = False
+    is_filtered: bool = False
+    rpki_state: int = RPKI_STATE_MAP.get("unknown", 2)
+
+    @property
+    def next_hop(self) -> str:
+        return self.gateway
+
+    @property
+    def age(self) -> int:
+        # MikroTik output does not provide route age, returning -1 to indicate unavailable.
+        return -1
+
+    @property
+    def weight(self) -> int:
+        return self.distance
+
+    @property
+    def med(self) -> int:
+        return self.metric
+
+    @property
+    def active(self) -> bool:
+        return self.is_active
+
+    @property
+    def all_communities(self) -> t.List[str]:
+        return self.communities + self.large_communities + self.ext_communities
+
+    @property
+    def source_as(self) -> int:
+        return self.as_path[-1] if self.as_path else 0
+
+    @property
+    def source_rid(self) -> str:
+        """Extract the IP/IPv6 address from belongs-to field.
+
+        Examples:
+            belongs-to="bgp-IP-196.60.96.109" -> "196.60.96.109"
+            belongs-to="bgp-IPv6-2001:43f8:6d0::11:141" -> "2001:43f8:6d0::11:141"
+        """
+        if not self.belongs_to:
+            return ""
+
+        # Remove bgp-IP- or bgp-IPv6- prefix
+        if self.belongs_to.startswith("bgp-IP-"):
+            return self.belongs_to[7:]  # len("bgp-IP-") = 7
+        elif self.belongs_to.startswith("bgp-IPv6-"):
+            return self.belongs_to[9:]  # len("bgp-IPv6-") = 9
+
+        return ""
+
+    @property
+    def peer_rid(self) -> str:
+        return self.gateway
+
+
+def _extract_paths(lines: t.List[str]) -> MikrotikPaths:
+    """Simple count based on lines with dst/dst-address and preferred 'A' flag."""
+    available = 0
+    best = 0
+    for raw in lines:
+        if ("dst-address=" in raw) or (" dst=" in f" {raw} "):
+            available += 1
+            m = FLAGS_RE.match(raw)
+            if m:
+                flags = set(m.group(1))
+                if "A" in flags:
+                    best += 1
+    return MikrotikPaths(available=available, best=best, select=best)
+
+
+def _process_kv(route: dict, key: str, val: str):
+    """Process a key-value pair and update the route dictionary."""
+    # Normalize quoted values
+    if val.startswith('"') and val.endswith('"'):
+        val = val[1:-1]
+
+    if key in ("dst-address", "dst"):
+        route["prefix"] = val
+    elif key in ("gateway", "nexthop"):
+        # Extract only the IP from gateway (e.g., 168.254.0.2%vlan-2000)
+        route["gateway"] = val.split("%")[0]
+    elif key == "distance":
+        route["distance"] = int(val) if val.isdigit() else route.get("distance", 0)
+    elif key == "scope":
+        route["scope"] = int(val) if val.isdigit() else route.get("scope", 0)
+    elif key in ("target-scope", "target_scope"):
+        route["target_scope"] = int(val) if val.isdigit() else route.get("target_scope", 0)
+
+    # v7 keys (with dot)
+    elif key in (".as-path", "as-path", "bgp-as-path"):
+        if val and val.lower() != "none":
+            # Find all numbers in the as-path string
+            nums = re.findall(r"\b\d{1,10}\b", val)
+            route["as_path"] = [int(n) for n in nums if 1 <= int(n) <= 4294967295]
+    elif key in (".origin", "origin", "bgp-origin"):
+        route["origin"] = val
+    elif key in (".med", "med", "bgp-med"):
+        route["metric"] = int(val) if val.isdigit() else 0
+    elif key in (".local-pref", "local-pref", "bgp-local-pref"):
+        route["local_preference"] = int(val) if val.isdigit() else 100
+    elif key in (".communities", "communities", "bgp-communities"):
+        if val and val.lower() != "none":
+            route["communities"] = [c.strip() for c in val.split(",") if c.strip()]
+    elif key in (".large-communities", "large-communities", "bgp-large-communities"):
+        if val and val.lower() != "none":
+            route["large_communities"] = [c.strip() for c in val.split(",") if c.strip()]
+    elif key == "bgp-ext-communities":
+        if val and val.lower() != "none":
+            route["ext_communities"] = [c.strip() for c in val.split(",") if c.strip()]
+    elif key == "rpki":
+        clean_val = val.strip().strip('"').lower()
+        route["rpki_state"] = RPKI_STATE_MAP.get(clean_val, 2)
+    elif key == "belongs-to":
+        route["belongs_to"] = val
+
+
+def _extract_route_entries(lines: t.List[str]) -> t.List[MikrotikRouteEntry]:
+    """Extract route entries from a list of lines."""
+    routes: t.List[MikrotikRouteEntry] = []
+    current_route_lines = []
+
+    for line in lines:
+        stripped_line = line.strip()
+        # A new route entry starts with flags or is a continuation line.
+        # An empty line signifies the end of the previous block.
+        if not stripped_line and current_route_lines:
+            # Process the completed route block
+            route_data = _parse_route_block(current_route_lines)
+            if route_data:
+                routes.append(route_data)
+            current_route_lines = []
+        elif stripped_line:
+            # Check if this line is the start of a new entry
+            if FLAGS_RE.match(stripped_line) and current_route_lines:
+                route_data = _parse_route_block(current_route_lines)
+                if route_data:
+                    routes.append(route_data)
+                current_route_lines = [stripped_line]
+            else:
+                current_route_lines.append(stripped_line)
+
+    # Process any remaining lines
+    if current_route_lines:
+        route_data = _parse_route_block(current_route_lines)
+        if route_data:
+            routes.append(route_data)
+
+    return routes
+
+
+def _parse_route_block(block: t.List[str]) -> t.Optional[MikrotikRouteEntry]:
+    """Parse a single route block and return a MikrotikRouteEntry."""
+    if not block:
+        return None
+
+    full_block_text = " ".join(block)
+    if "dst-address=" not in full_block_text and " dst=" not in f" {full_block_text} ":
+        return None
+
+    flags = ""
+    rd = {
+        "prefix": "",
+        "gateway": "",
+        "distance": 20,
+        "scope": 30,
+        "target_scope": 10,
+        "as_path": [],
+        "communities": [],
+        "large_communities": [],
+        "ext_communities": [],
+        "local_preference": 100,
+        "metric": 0,
+        "origin": "",
+        "belongs_to": "",
+        "is_active": False,
+        "is_filtered": False,
+        "rpki_state": RPKI_STATE_MAP.get("unknown", 2),
+    }
+
+    # Interpret flags in the first line:
+    # - "A" => active (preferred)
+    # - otherwise not active
+    m = FLAGS_RE.match(block[0])
+    if m:
+        flags = m.group(1)
+        flag_set = set(flags)
+        is_active = "A" in flag_set
+        is_filtered = bool(flag_set & {"F", "f", "U", "u", "X", "x"})
+
+        if is_active:
+            rd["is_active"] = True
+            rd["is_filtered"] = False
+        else:
+            rd["is_filtered"] = is_filtered
+
+    # Find all key=value tokens in the entire block
+    for k, v in TOKEN_RE.findall(full_block_text):
+        _process_kv(rd, k, v)
+
+    if rd["prefix"]:
+        try:
+            if Settings.debug:
+                log.bind(parser="MikrotikBGPTable").debug(
+                    "Parsed MikroTik route entry: "
+                    "prefix={prefix} flags={flags} active={active} filtered={filtered} "
+                    "next_hop={next_hop} as_path={as_path} rpki_state={rpki_state}",
+                    prefix=rd["prefix"],
+                    flags=flags or None,
+                    active=rd["is_active"],
+                    filtered=rd["is_filtered"],
+                    next_hop=rd["gateway"] or None,
+                    as_path=rd["as_path"],
+                    rpki_state=rd["rpki_state"],
+                )
+            return MikrotikRouteEntry(**rd)
+        except Exception as e:
+            log.warning(f"Failed to create MikroTik route entry ({rd.get('prefix','?')}: {e}")
+    return None
+
+
+class MikrotikBGPRouteTable(BGPRouteTable):
+    """Canonical MikroTik BGP Route Table."""
+
+    # No custom __init__ needed; inherit from BGPRouteTable (which should be a Pydantic model)
+
+
+class MikrotikBGPTable(MikrotikBase):
+    """MikroTik BGP Table in canonical format."""
+
+    local_router_id: str = ""
+    local_as_number: int = 0
+    paths: MikrotikPaths = MikrotikPaths()
+    routes: t.List[MikrotikRouteEntry] = []
+
+    @classmethod
+    def parse_text(cls, text: str) -> "MikrotikBGPTable":
+        _log = log.bind(parser="MikrotikBGPTable")
+        inst = cls()
+
+        lines = text.splitlines()
+        if not lines:
+            return inst
+
+        # Filter out command echoes and header lines
+        lines = [ln for ln in lines if not ln.strip().startswith((">", "Flags:", "[", "#"))]
+
+        inst.paths = _extract_paths(lines)
+        inst.routes = _extract_route_entries(lines)
+
+        _log.debug(f"Parsed {len(inst.routes)} MikroTik routes")
+        return inst
+
+    def bgp_table(self) -> BGPRouteTable:
+        routes = []
+        for route in self.routes:
+            route_data = {
+                "prefix": route.prefix,
+                "active": route.active,
+                "age": route.age,
+                "weight": route.weight,
+                "med": route.med,
+                "local_preference": route.local_preference,
+                "as_path": route.as_path,
+                "communities": route.all_communities,
+                "next_hop": route.next_hop,
+                "source_as": route.source_as,
+                "source_rid": route.source_rid,
+                "peer_rid": route.peer_rid,
+                "rpki_state": route.rpki_state,
+                "filtered": route.is_filtered,
+            }
+            # Instantiate BGPRoute to trigger validation (including external RPKI)
+            routes.append(BGPRoute(**route_data))
+        return MikrotikBGPRouteTable(
+            vrf="default",
+            count=len(routes),
+            routes=routes,
+            winning_weight="low",
+        )
+
+
+class MikrotikTracerouteTable(MikrotikBase):
+    """MikroTik Traceroute Table."""
+
+    target: str
+    source: str
+    hops: t.List["MikrotikTracerouteHop"] = []
+    max_hops: int = 30
+    packet_size: int = 60
+
+    @classmethod
+    def parse_text(cls, text: str, target: str, source: str) -> "MikrotikTracerouteTable":
+        """Parse a cleaned MikroTik traceroute table.
+
+        The input is expected to be a single, clean traceroute table that has already
+        been processed by the garbage cleaner to remove paging artifacts and duplicates.
+
+        Expected format:
+        ADDRESS                          LOSS SENT    LAST     AVG    BEST   WORST STD-DEV STATUS
+        197.157.67.233                     0%    3   0.4ms     0.2     0.1     0.4     0.1
+                                         100%    3 timeout
+        41.78.188.153                      0%    3 210.8ms   210.8   210.8   210.9       0
+        """
+        _log = log.bind(parser="MikrotikTracerouteTable")
+
+        _log.debug(
+            "Parsing cleaned MikroTik traceroute table",
+            target=target,
+            source=source,
+            lines=len(text.splitlines()),
+        )
+
+        lines = text.strip().split("\n")
+        hops = []
+        hop_number = 1
+
+        # Find the table header to start parsing from
+        header_found = False
+        data_start_index = 0
+        has_index_column = False
+
+        for i, line in enumerate(lines):
+            if "ADDRESS" in line and "LOSS" in line and "SENT" in line:
+                header_found = True
+                data_start_index = i + 1
+                # Some RouterOS versions prefix each row with a hop-index column,
+                # so the header begins with "#" (e.g. "# ADDRESS LOSS SENT ...").
+                # Detect it here so the data rows can drop that leading column.
+                header_tokens = line.split()
+                has_index_column = bool(header_tokens) and header_tokens[0] == "#"
+                break
+
+        if not header_found:
+            _log.warning("No traceroute table header found in cleaned output")
+            return MikrotikTracerouteTable(target=target, source=source, hops=[])
+
+        # Parse data rows
+        for i in range(data_start_index, len(lines)):
+            line = lines[i].strip()
+
+            # Skip empty lines
+            if not line:
+                continue
+
+            # Stop at any remaining paging markers (shouldn't happen with cleaned input)
+            if "-- [Q quit|C-z pause]" in line:
+                break
+
+            try:
+                # Parse data line
+                parts = line.split()
+                # Drop the leading hop-index column when present (e.g. "0  1.2.3.4 ...").
+                if has_index_column and parts and re.fullmatch(r"\d+", parts[0]):
+                    parts = parts[1:]
+                if len(parts) < 3:
+                    continue
+
+                # Check if this is a timeout line (starts with percentage)
+                if parts[0].endswith("%"):
+                    # Timeout hop: "100% 3 timeout"
+                    ip_address = None
+                    loss_pct = int(parts[0].rstrip("%"))
+                    sent_count = int(parts[1])
+                    last_rtt = None
+                    avg_rtt = None
+                    best_rtt = None
+                    worst_rtt = None
+                else:
+                    # Normal hop: "197.157.67.233 0% 3 0.4ms 0.2 0.1 0.4 0.1"
+                    ip_address = parts[0]
+                    if len(parts) < 7:
+                        continue
+
+                    loss_pct = int(parts[1].rstrip("%"))
+                    sent_count = int(parts[2])
+
+                    # Parse RTT values
+                    def parse_rtt(rtt_str: str) -> t.Optional[float]:
+                        if rtt_str in ("timeout", "-", "0ms", "*"):
+                            return None
+                        rtt_clean = re.sub(r"ms$", "", rtt_str)
+                        try:
+                            return float(rtt_clean)
+                        except ValueError:
+                            return None
+
+                    last_rtt = parse_rtt(parts[3])
+                    avg_rtt = parse_rtt(parts[4])
+                    best_rtt = parse_rtt(parts[5])
+                    worst_rtt = parse_rtt(parts[6])
+
+                hop = MikrotikTracerouteHop(
+                    hop_number=hop_number,
+                    ip_address=ip_address,
+                    hostname=None,  # MikroTik doesn't do reverse DNS by default
+                    loss_pct=loss_pct,
+                    sent_count=sent_count,
+                    last_rtt=last_rtt,
+                    avg_rtt=avg_rtt,
+                    best_rtt=best_rtt,
+                    worst_rtt=worst_rtt,
+                )
+
+                hops.append(hop)
+                hop_number += 1
+
+            except (ValueError, IndexError) as e:
+                _log.debug("Failed to parse traceroute data line", line=line, error=str(e))
+                continue
+
+        result = MikrotikTracerouteTable(target=target, source=source, hops=hops)
+        _log.info("Parsed cleaned traceroute table", hops=len(hops))
+        return result
+
+    def traceroute_result(self):
+        """Convert to TracerouteResult format."""
+        from hyperglass.models.data.traceroute import TracerouteResult, TracerouteHop
+        from hyperglass.log import log
+
+        _log = log.bind(parser="MikrotikTracerouteTable")
+
+        converted_hops = []
+        for hop in self.hops:
+            # Handle truncated IP addresses
+            ip_address = hop.ip_address
+            display_ip = None
+
+            if hop.ip_address and hop.ip_address.endswith("..."):
+                # For truncated IPs, store for display but set ip_address to None for validation
+                display_ip = hop.ip_address
+                ip_address = None
+
+            created_hop = TracerouteHop(
+                hop_number=hop.hop_number,
+                ip_address=ip_address,  # None for truncated IPs
+                display_ip=display_ip,  # Truncated IP for display
+                hostname=hop.hostname,
+                # Set RTT values to ensure avg_rtt property returns MikroTik's AVG value
+                # Since avg_rtt = (rtt1 + rtt2 + rtt3) / 3, we set all to the MikroTik AVG
+                rtt1=hop.avg_rtt,  # Set to AVG so computed average is correct
+                rtt2=hop.avg_rtt,  # Set to AVG so computed average is correct
+                rtt3=hop.avg_rtt,  # Set to AVG so computed average is correct
+                # MikroTik-specific statistics (preserve original values)
+                loss_pct=hop.loss_pct,
+                sent_count=hop.sent_count,
+                last_rtt=hop.last_rtt,  # Preserve LAST value
+                best_rtt=hop.best_rtt,  # Preserve BEST value
+                worst_rtt=hop.worst_rtt,  # Preserve WORST value
+                # BGP enrichment fields will be populated by enrichment plugin
+                # For truncated IPs, these will remain None/empty
+                asn=None,
+                org=None,
+                prefix=None,
+                country=None,
+                rir=None,
+                allocated=None,
+            )
+
+            converted_hops.append(created_hop)
+
+        return TracerouteResult(
+            target=self.target,
+            source=self.source,
+            hops=converted_hops,
+            max_hops=self.max_hops,
+            packet_size=self.packet_size,
+            raw_output=None,  # Will be set by the plugin
+        )
+
+
+class MikrotikTracerouteHop(MikrotikBase):
+    """Individual MikroTik traceroute hop."""
+
+    hop_number: int
+    ip_address: t.Optional[str] = None
+    hostname: t.Optional[str] = None
+
+    # MikroTik-specific statistics
+    loss_pct: t.Optional[int] = None
+    sent_count: t.Optional[int] = None
+    last_rtt: t.Optional[float] = None
+    avg_rtt: t.Optional[float] = None
+    best_rtt: t.Optional[float] = None
+    worst_rtt: t.Optional[float] = None
+
+    @property
+    def is_timeout(self) -> bool:
+        """Check if this hop is a timeout."""
+        return self.ip_address is None or self.loss_pct == 100

--- a/hyperglass/plugins/_builtin/__init__.py
+++ b/hyperglass/plugins/_builtin/__init__.py
@@ -5,14 +5,30 @@ from .bgp_route_frr import BGPRoutePluginFrr
 from .remove_command import RemoveCommand
 from .bgp_route_arista import BGPRoutePluginArista
 from .bgp_route_huawei import BGPRoutePluginHuawei
+from .bgp_routestr_huawei import BGPSTRRoutePluginHuawei
 from .bgp_route_juniper import BGPRoutePluginJuniper
 from .mikrotik_garbage_output import MikrotikGarbageOutput
+from .mikrotik_normalize_input import MikrotikTargetNormalizerInput
+from .bgp_routestr_mikrotik import BGPSTRRoutePluginMikrotik
+from .trace_route_frr import TraceroutePluginFrr
+from .trace_route_huawei import TraceroutePluginHuawei
+from .trace_route_mikrotik import TraceroutePluginMikrotik
+from .traceroute_ip_enrichment import ZTracerouteIpEnrichment
+from .bgp_route_enrichment import ZBgpRouteEnrichment
 
 __all__ = (
     "BGPRoutePluginArista",
     "BGPRoutePluginFrr",
     "BGPRoutePluginJuniper",
     "BGPRoutePluginHuawei",
+    "BGPSTRRoutePluginHuawei",
     "MikrotikGarbageOutput",
+    "MikrotikTargetNormalizerInput",
+    "BGPSTRRoutePluginMikrotik",
+    "TraceroutePluginFrr",
+    "TraceroutePluginHuawei",
+    "TraceroutePluginMikrotik",
+    "ZTracerouteIpEnrichment",
+    "ZBgpRouteEnrichment",
     "RemoveCommand",
 )

--- a/hyperglass/plugins/_builtin/mikrotik_garbage_output.py
+++ b/hyperglass/plugins/_builtin/mikrotik_garbage_output.py
@@ -8,6 +8,7 @@ import typing as t
 from pydantic import PrivateAttr
 
 # Project
+from hyperglass.log import log
 from hyperglass.types import Series
 
 # Local
@@ -19,64 +20,246 @@ if t.TYPE_CHECKING:
 
 
 class MikrotikGarbageOutput(OutputPlugin):
-    """Parse Mikrotik output to remove garbage."""
+    """Parse Mikrotik output to remove garbage before structured parsing."""
 
     _hyperglass_builtin: bool = PrivateAttr(True)
-    platforms: t.Sequence[str] = ("mikrotik_routeros", "mikrotik_switchos")
-    directives: t.Sequence[str] = (
-        "__hyperglass_mikrotik_bgp_aspath__",
-        "__hyperglass_mikrotik_bgp_community__",
-        "__hyperglass_mikrotik_bgp_route__",
-        "__hyperglass_mikrotik_ping__",
-        "__hyperglass_mikrotik_traceroute__",
-    )
+    platforms: t.Sequence[str] = ("mikrotik_routeros", "mikrotik_switchos", "mikrotik")
+    # Only apply to MikroTik platforms, not all devices
+    common: bool = False
+
+    def _clean_traceroute_output(self, raw_output: str) -> str:
+        """Clean MikroTik traceroute output specifically.
+
+        Important: Traceroute hops are sequential - each line represents a unique hop position.
+        We should NOT deduplicate by IP address as the same IP can appear at different hops.
+        Order matters for traceroute results.
+
+        However, we can aggregate consecutive timeout lines at the END of the traceroute
+        to avoid showing 10+ meaningless timeout entries.
+        """
+        if not raw_output or not raw_output.strip():
+            return ""
+
+        lines = raw_output.splitlines()
+        # Remove command echoes and paging, keep only header markers and data lines
+        # We'll split the output into discrete tables (each table begins at a header)
+        tables: t.List[t.List[str]] = []
+        current_table: t.List[str] = []
+        header_line: t.Optional[str] = None
+
+        for line in lines:
+            stripped = line.strip()
+
+            # Skip empty lines and interactive paging prompts
+            if (
+                not stripped
+                or "-- [Q quit|C-z pause]" in stripped
+                or "-- [Q quit|D dump|C-z pause]" in stripped
+            ):
+                continue
+
+            # Skip command echo lines
+            if "tool traceroute" in stripped:
+                continue
+
+            # If this is a header line, start a new table
+            if "ADDRESS" in stripped and "LOSS" in stripped and "SENT" in stripped:
+                header_line = line
+                # If we were collecting a table, push it
+                if current_table:
+                    tables.append(current_table)
+                    current_table = []
+                # Start collecting after header
+                continue
+
+            # Collect data lines (will be associated with the most recent header)
+            if header_line is not None:
+                current_table.append(line)
+
+        # Push the last collected table if any
+        if current_table:
+            tables.append(current_table)
+
+        # If we didn't find any header/data, return cleaned minimal output
+        if not tables:
+            # Fallback to previous behavior: remove prompts and flags
+            filtered_lines: t.List[str] = []
+            in_flags_section = False
+            for line in lines:
+                stripped_line = line.strip()
+                if stripped_line.startswith("@") and stripped_line.endswith("] >"):
+                    continue
+                if "[Q quit|D dump|C-z pause]" in stripped_line:
+                    continue
+                if stripped_line.startswith("Flags:"):
+                    in_flags_section = True
+                    continue
+                if in_flags_section:
+                    if "=" in stripped_line:
+                        in_flags_section = False
+                    else:
+                        continue
+                filtered_lines.append(line)
+            return "\n".join(filtered_lines)
+
+        # Aggregate tables by hop index. For each hop position, pick the row with the
+        # highest SENT count. If SENT ties, prefer non-timeout rows and the later table.
+        processed_lines: t.List[str] = []
+
+        # Regex to extract LOSS% and SENT count following it: e.g. '0%    3'
+        sent_re = re.compile(r"(\d+)%\s+(\d+)\b")
+
+        max_rows = max(len(t) for t in tables)
+
+        for i in range(max_rows):
+            best_row = None
+            best_sent = -1
+            best_is_timeout = True
+            best_table_index = -1
+
+            for ti, table in enumerate(tables):
+                if i >= len(table):
+                    continue
+                row = table[i]
+                m = sent_re.search(row)
+                if m:
+                    try:
+                        sent = int(m.group(2))
+                    except Exception:
+                        sent = 0
+                else:
+                    sent = 0
+
+                is_timeout = "timeout" in row.lower() or (
+                    "100%" in row and "timeout" in row.lower()
+                )
+
+                # Prefer higher SENT, then prefer non-timeout, then later table (higher ti)
+                pick = False
+                if sent > best_sent:
+                    pick = True
+                elif sent == best_sent:
+                    if best_is_timeout and not is_timeout:
+                        pick = True
+                    elif (best_is_timeout == is_timeout) and ti > best_table_index:
+                        pick = True
+
+                if pick:
+                    best_row = row
+                    best_sent = sent
+                    best_is_timeout = is_timeout
+                    best_table_index = ti
+
+            if best_row is not None:
+                processed_lines.append(best_row)
+
+        # Collapse excessive trailing timeouts into an aggregation line
+        trailing_timeouts = 0
+        for line in reversed(processed_lines):
+            if ("timeout" in line.lower()) or (
+                sent_re.search(line) and sent_re.search(line).group(1) == "100"
+            ):
+                trailing_timeouts += 1
+            else:
+                break
+
+        if trailing_timeouts > 3:
+            non_trailing = len(processed_lines) - trailing_timeouts
+            # Keep first 2 of trailing timeouts and aggregate the rest
+            aggregated = (
+                processed_lines[:non_trailing] + processed_lines[non_trailing : non_trailing + 2]
+            )
+            remaining = trailing_timeouts - 2
+            aggregated.append(
+                f"                                 ... ({remaining} more timeout hops)"
+            )
+            processed_lines = aggregated
+
+        # Prepend header line if we have one
+        header_to_use = (
+            header_line
+            or "ADDRESS                          LOSS SENT    LAST     AVG    BEST   WORST STD-DEV STATUS"
+        )
+        cleaned = [header_to_use] + processed_lines
+        return "\n".join(cleaned)
 
     def process(self, *, output: OutputType, query: "Query") -> Series[str]:
-        """Parse Mikrotik output to remove garbage."""
+        """
+        Clean raw output from a MikroTik device.
+        This plugin removes command echoes, prompts, flag legends, and interactive help text.
+        """
 
-        result = ()
+        # If output is already processed/structured (not raw strings), pass it through unchanged
+        if not isinstance(output, (tuple, list)):
+            return output
 
-        for each_output in output:
-            if len(each_output) != 0:
-                if each_output.split()[-1] in ("DISTANCE", "STATUS"):
-                    # Mikrotik shows the columns with no rows if there is no data.
-                    # Rather than send back an empty table, send back an empty
-                    # response which is handled with a warning message.
-                    each_output = ""
-                else:
-                    remove_lines = ()
-                    all_lines = each_output.splitlines()
-                    # Starting index for rows (after the column row).
-                    start = 1
-                    # Extract the column row.
-                    column_line = " ".join(all_lines[0].split())
+        # Check if the tuple/list contains non-string objects (structured data)
+        if output and not isinstance(output[0], str):
+            return output
 
-                    for i, line in enumerate(all_lines[1:]):
-                        # Remove all the newline characters (which differ line to
-                        # line) for comparison purposes.
-                        normalized = " ".join(line.split())
+        cleaned_outputs = []
 
-                        # Remove ansii characters that aren't caught by Netmiko.
-                        normalized = re.sub(r"\\x1b\[\S{2}\s", "", normalized)
+        for raw_output in output:
+            # Handle non-string outputs (already processed by other plugins) - double check
+            if not isinstance(raw_output, str):
+                cleaned_outputs.append(raw_output)
+                continue
 
-                        if column_line in normalized:
-                            # Mikrotik often re-inserts the column row in the output,
-                            # effectively 'starting over'. In that case, re-assign
-                            # the column row and starting index to that point.
-                            column_line = re.sub(r"\[\S{2}\s", "", line)
-                            start = i + 2
+            # Nothing to do if the output is already empty.
+            if not raw_output or not raw_output.strip():
+                cleaned_outputs.append("")
+                continue
 
-                        if "[Q quit|D dump|C-z pause]" in normalized:
-                            # Remove Mikrotik's unhelpful helpers from the output.
-                            remove_lines += (i + 1,)
+            # Check if this is traceroute output and handle it specially
+            if (
+                "tool traceroute" in raw_output
+                or ("ADDRESS" in raw_output and "LOSS" in raw_output and "SENT" in raw_output)
+                or "-- [Q quit|C-z pause]" in raw_output
+            ):
+                cleaned_output = self._clean_traceroute_output(raw_output)
+                cleaned_outputs.append(cleaned_output)
+                continue
 
-                    # Combine the column row and the data rows from the starting
-                    # index onward.
-                    lines = [column_line, *all_lines[start:]]
+            # Original logic for other outputs (BGP routes, etc.)
+            lines = raw_output.splitlines()
+            filtered_lines = []
+            in_flags_section = False
 
-                    # Remove any lines marked for removal and re-join with a single
-                    # newline character.
-                    lines = [line for idx, line in enumerate(lines) if idx not in remove_lines]
-                    result += ("\n".join(lines),)
+            for line in lines:
+                stripped_line = line.strip()
 
-        return result
+                # Skip prompts and command echoes
+                if stripped_line.startswith("@") and stripped_line.endswith("] >"):
+                    continue
+
+                # Skip the interactive help line
+                if "[Q quit|D dump|C-z pause]" in stripped_line:
+                    continue
+
+                # Begin detecting the Flags section
+                if stripped_line.startswith("Flags:"):
+                    in_flags_section = True
+                    continue  # Skip the "Flags:" line itself
+
+                # Within the flags section, check whether the line is still part of it
+                if in_flags_section:
+                    if "=" in stripped_line:
+                        in_flags_section = False
+                    else:
+                        continue  # Skip the flag-legend lines
+
+                filtered_lines.append(line)
+
+            # Join the cleaned lines back into a single string
+            cleaned_output = "\n".join(filtered_lines)
+            cleaned_outputs.append(cleaned_output)
+
+        # Minimal debug logging: log number of cleaned blocks and if any aggregation occurred
+        if len(output) > 0:
+            log.debug(f"MikrotikGarbageOutput processed {len(output)} output blocks.")
+        # If any aggregation line was added, log that event
+        for cleaned in cleaned_outputs:
+            if "... (" in cleaned:
+                log.debug("Aggregated excessive trailing timeout hops in traceroute output.")
+                break
+        return tuple(cleaned_outputs)

--- a/hyperglass/plugins/_builtin/mikrotik_normalize_input.py
+++ b/hyperglass/plugins/_builtin/mikrotik_normalize_input.py
@@ -1,0 +1,58 @@
+# Standard Library
+from ipaddress import ip_network, ip_address
+import typing as t
+
+# Third Party
+from pydantic import PrivateAttr
+
+# Project
+from hyperglass.log import log
+
+# REMOVIDA a importação direta de Query para evitar o erro circular
+# from hyperglass.models.api.query import Query
+
+# Local
+from .._input import InputPlugin, InputPluginValidationReturn
+
+
+class MikrotikTargetNormalizerInput(InputPlugin):
+    """
+    InputPlugin to normalize a target IP address to its network prefix.
+    This ensures that queries for different IPs within the same subnet
+    resolve to the same cache key.
+    """
+
+    _hyperglass_builtin: bool = PrivateAttr(False)
+    name: str = "mikrotik_normalizer"
+    platforms: t.Sequence[str] = ("mikrotik_routeros", "mikrotik_switchos", "mikrotik")
+
+    def validate(self, query: t.Any) -> InputPluginValidationReturn:
+        """Take the query object and modify the target if it's a BGP Route query."""
+
+        # Acessamos os atributos normalmente, pois sabemos que o objeto 'query' os terá.
+        if query.query_type != "bgp_route":
+            return True, None
+
+        try:
+            target_ip = ip_address(query.target)
+
+            if target_ip.version == 4:
+                prefix_len = 24
+            else:
+                prefix_len = 48
+
+            network = ip_network(f"{str(target_ip)}/{prefix_len}", strict=False)
+
+            normalized_target = str(network.with_prefixlen)
+
+            if query.target != normalized_target:
+                log.debug(
+                    f"Normalizing target '{query.target}' to network prefix "
+                    f"'{normalized_target}' for MikroTik cache key."
+                )
+                query.target = normalized_target
+
+        except ValueError:
+            pass
+
+        return True, None

--- a/hyperglass/plugins/_builtin/trace_route_frr.py
+++ b/hyperglass/plugins/_builtin/trace_route_frr.py
@@ -1,0 +1,345 @@
+"""Parse FRR traceroute output to structured data."""
+
+# Standard Library
+import re
+import typing as t
+from ipaddress import ip_address as validate_ip
+
+# Third Party
+from pydantic import PrivateAttr
+
+# Project
+from hyperglass.log import log
+from hyperglass.exceptions.private import ParsingError
+from hyperglass.models.data.traceroute import TracerouteResult, TracerouteHop
+from hyperglass.state import use_state
+
+# Local
+from .._output import OutputPlugin
+
+if t.TYPE_CHECKING:
+    from hyperglass.models.data import OutputDataModel
+    from hyperglass.models.api.query import Query
+    from .._output import OutputType
+
+
+def _normalize_output(output: t.Union[str, t.Sequence[str]]) -> t.List[str]:
+    """Ensure the output is a list of strings."""
+    if isinstance(output, str):
+        return [output]
+    return list(output)
+
+
+def parse_frr_traceroute(
+    output: t.Union[str, t.Sequence[str]], target: str, source: str
+) -> "OutputDataModel":
+    """Parse an FRR traceroute text response."""
+    result = None
+    out_list = _normalize_output(output)
+
+    _log = log.bind(plugin=TraceroutePluginFrr.__name__)
+    combined_output = "\n".join(out_list)
+
+    # DEBUG: Log the raw output we're about to parse
+    _log.debug(f"=== FRR TRACEROUTE PLUGIN RAW INPUT ===")
+    _log.debug(f"Target: {target}, Source: {source}")
+    _log.debug(f"Output pieces: {len(out_list)}")
+    _log.debug(f"Combined output length: {len(combined_output)}")
+    _log.debug(f"First 500 chars: {repr(combined_output[:500])}")
+    _log.debug(f"=== END PLUGIN RAW INPUT ===")
+
+    try:
+        result = FrrTracerouteTable.parse_text(combined_output, target, source)
+    except Exception as exc:
+        _log.error(f"Failed to parse FRR traceroute: {exc}")
+        raise ParsingError(f"Failed to parse FRR traceroute output: {exc}") from exc
+
+    _log.debug(f"=== FINAL STRUCTURED TRACEROUTE RESULT ===")
+    _log.debug(f"Successfully parsed {len(result.hops)} traceroute hops")
+    _log.debug(f"Target: {target}, Source: {source}")
+    for hop in result.hops:
+        _log.debug(f"Hop {hop.hop_number}: {hop.ip_address or '*'} - RTT: {hop.rtt1 or 'timeout'}")
+    _log.debug(f"Raw output length: {len(combined_output)} characters")
+    _log.debug(f"=== END STRUCTURED RESULT ===")
+
+    return result
+
+
+class FrrTracerouteTable(TracerouteResult):
+    """FRR traceroute table parser."""
+
+    @classmethod
+    def parse_text(cls, text: str, target: str, source: str) -> TracerouteResult:
+        """Parse FRR traceroute text output into structured data."""
+        _log = log.bind(parser="FrrTracerouteTable")
+
+        _log.debug(f"=== RAW FRR TRACEROUTE INPUT ===")
+        _log.debug(f"Target: {target}, Source: {source}")
+        _log.debug(f"Raw text length: {len(text)} characters")
+        _log.debug(f"Raw text:\n{repr(text)}")
+        _log.debug(f"=== END RAW INPUT ===")
+
+        hops = []
+
+        # Parse the traceroute output line by line
+        lines = text.strip().split("\n")
+        _log.debug(f"Split into {len(lines)} lines")
+
+        # Patterns for different line formats
+        # Pattern for regular hop: " 1  203.0.113.1  0.221 ms"
+        simple_pattern = re.compile(r"^\s*(\d+)\s+([\d\.:a-fA-F]+)\s+([\d.]+)\s+ms")
+
+        # Pattern for timeout hop: " 9  *"
+        timeout_pattern = re.compile(r"^\s*(\d+)\s+\*\s*$")
+
+        # Pattern for hop with hostname: " 2  hostname.example.com (192.168.1.1)  15.234 ms"
+        hostname_pattern = re.compile(r"^\s*(\d+)\s+(\S+)\s+\(([\d\.:a-fA-F]+)\)\s+([\d.]+)\s+ms")
+
+        # Pattern for multiple RTTs: " 3  192.168.1.1  15.234 ms  16.123 ms  14.567 ms"
+        multi_rtt_pattern = re.compile(
+            r"^\s*(\d+)\s+([\d\.:a-fA-F]+)\s+([\d.]+)\s+ms(?:\s+([\d.]+)\s+ms)?(?:\s+([\d.]+)\s+ms)?"
+        )
+
+        # Pattern for partial timeout: " 7  port-channel4.core4.mrs1.he.net (184.105.81.30)  132.624 ms  132.589 ms *"
+        partial_timeout_pattern = re.compile(
+            r"^\s*(\d+)\s+(\S+)\s+\(([\d\.:a-fA-F]+)\)\s+(?:([\d.]+)\s+ms\s+)?(?:([\d.]+)\s+ms\s+)?\*"
+        )
+
+        for i, line in enumerate(lines):
+            line = line.strip()
+            if not line:
+                continue
+
+            _log.debug(f"Line {i:2}: {repr(line)}")
+
+            # Skip header lines
+            if "traceroute to" in line.lower() or "hops max" in line.lower():
+                _log.debug(f"Line {i:2}: SKIPPING HEADER")
+                continue
+
+            hop_number = None
+            ip_address = None
+            hostname = None
+            rtt1 = None
+            rtt2 = None
+            rtt3 = None
+
+            # Try to match timeout hop first
+            timeout_match = timeout_pattern.match(line)
+            if timeout_match:
+                hop_number = int(timeout_match.group(1))
+                _log.debug(f"Line {i:2}: TIMEOUT HOP - {hop_number}")
+
+            # Try to match partial timeout
+            elif partial_timeout_pattern.match(line):
+                partial_match = partial_timeout_pattern.match(line)
+                hop_number = int(partial_match.group(1))
+                hostname = partial_match.group(2)
+                ip_address = partial_match.group(3)
+                rtt1 = float(partial_match.group(4)) if partial_match.group(4) else None
+                rtt2 = float(partial_match.group(5)) if partial_match.group(5) else None
+                _log.debug(
+                    f"Line {i:2}: PARTIAL TIMEOUT HOP - {hop_number}: {hostname} ({ip_address}) {rtt1} {rtt2} *"
+                )
+
+            # Try to match hostname pattern
+            elif hostname_pattern.match(line):
+                hostname_match = hostname_pattern.match(line)
+                hop_number = int(hostname_match.group(1))
+                hostname = hostname_match.group(2)
+                ip_address = hostname_match.group(3)
+                rtt1 = float(hostname_match.group(4))
+                _log.debug(
+                    f"Line {i:2}: HOSTNAME HOP - {hop_number}: {hostname} ({ip_address}) {rtt1} ms"
+                )
+
+            # Try to match multiple RTT pattern
+            elif multi_rtt_pattern.match(line):
+                multi_match = multi_rtt_pattern.match(line)
+                hop_number = int(multi_match.group(1))
+                ip_address = multi_match.group(2)
+                rtt1 = float(multi_match.group(3))
+                rtt2 = float(multi_match.group(4)) if multi_match.group(4) else None
+                rtt3 = float(multi_match.group(5)) if multi_match.group(5) else None
+                _log.debug(
+                    f"Line {i:2}: MULTI RTT HOP - {hop_number}: {ip_address} {rtt1} {rtt2} {rtt3}"
+                )
+
+            # Try to match simple pattern
+            elif simple_pattern.match(line):
+                simple_match = simple_pattern.match(line)
+                hop_number = int(simple_match.group(1))
+                ip_address = simple_match.group(2)
+                rtt1 = float(simple_match.group(3))
+                _log.debug(f"Line {i:2}: SIMPLE IP HOP - {hop_number}: {ip_address} {rtt1} ms")
+
+            else:
+                _log.debug(f"Line {i:2}: NO MATCH - skipping")
+                continue
+
+            # Create hop object if we have valid data
+            if hop_number is not None:
+                try:
+                    # Validate IP address if present
+                    if ip_address:
+                        validate_ip(ip_address)
+                except ValueError:
+                    # If IP validation fails, treat as hostname
+                    if not hostname:
+                        hostname = ip_address
+                    ip_address = None
+
+                hop = TracerouteHop(
+                    hop_number=hop_number,
+                    ip_address=ip_address,
+                    display_ip=None,
+                    hostname=hostname,
+                    rtt1=rtt1,
+                    rtt2=rtt2,
+                    rtt3=rtt3,
+                    sent_count=None,
+                    last_rtt=rtt1,
+                    best_rtt=(
+                        min(filter(None, [rtt1, rtt2, rtt3])) if any([rtt1, rtt2, rtt3]) else None
+                    ),
+                    worst_rtt=(
+                        max(filter(None, [rtt1, rtt2, rtt3])) if any([rtt1, rtt2, rtt3]) else None
+                    ),
+                    loss_pct=None,
+                    # BGP enrichment fields (will be populated by enrichment plugin)
+                    asn=None,
+                    org=None,
+                    prefix=None,
+                    country=None,
+                    rir=None,
+                    allocated=None,
+                )
+                hops.append(hop)
+
+        # Clean up hops - remove duplicates and sort by hop number
+        _log.debug(f"Before cleanup: {len(hops)} hops")
+
+        # Group hops by hop number and merge data
+        hop_dict = {}
+        for hop in hops:
+            if hop.hop_number in hop_dict:
+                # Merge data for same hop number
+                existing = hop_dict[hop.hop_number]
+                # Keep the first non-None value for each field
+                hop_dict[hop.hop_number] = TracerouteHop(
+                    hop_number=hop.hop_number,
+                    ip_address=existing.ip_address or hop.ip_address,
+                    display_ip=existing.display_ip or hop.display_ip,
+                    hostname=existing.hostname or hop.hostname,
+                    rtt1=existing.rtt1 or hop.rtt1,
+                    rtt2=existing.rtt2 or hop.rtt2,
+                    rtt3=existing.rtt3 or hop.rtt3,
+                    sent_count=existing.sent_count or hop.sent_count,
+                    last_rtt=existing.last_rtt or hop.last_rtt,
+                    best_rtt=existing.best_rtt or hop.best_rtt,
+                    worst_rtt=existing.worst_rtt or hop.worst_rtt,
+                    loss_pct=existing.loss_pct or hop.loss_pct,
+                    asn=existing.asn or hop.asn,
+                    org=existing.org or hop.org,
+                    prefix=existing.prefix or hop.prefix,
+                    country=existing.country or hop.country,
+                    rir=existing.rir or hop.rir,
+                    allocated=existing.allocated or hop.allocated,
+                )
+            else:
+                hop_dict[hop.hop_number] = hop
+
+        # Convert back to sorted list
+        final_hops = [hop_dict[hop_num] for hop_num in sorted(hop_dict.keys())]
+        _log.debug(f"After cleanup: {len(final_hops)} hops")
+
+        # Debug final hop list
+        for hop in final_hops:
+            hostname_display = hop.hostname or "no-hostname"
+            _log.debug(
+                f"Final hop {hop.hop_number}: {hop.ip_address} ({hostname_display}) - RTTs: {hop.rtt1}/{hop.rtt2}/{hop.rtt3}"
+            )
+
+        _log.info(f"Parsed {len(final_hops)} hops from FRR traceroute")
+
+        # Extract packet information from traceroute output
+        max_hops = 30  # Default
+        packet_size = 60  # FRR default
+
+        # Try to extract from header line
+        for line in lines:
+            if "hops max" in line.lower():
+                try:
+                    # Look for pattern like "30 hops max, 60 byte packets"
+                    match = re.search(r"(\d+)\s+hops\s+max.*?(\d+)\s+byte", line)
+                    if match:
+                        max_hops = int(match.group(1))
+                        packet_size = int(match.group(2))
+                        break
+                except (ValueError, AttributeError):
+                    pass
+
+        return TracerouteResult(
+            target=target,
+            source=source,
+            hops=final_hops,
+            max_hops=max_hops,
+            packet_size=packet_size,
+            raw_output=text,
+            asn_organizations={},
+        )
+
+
+class TraceroutePluginFrr(OutputPlugin):
+    """Parse FRR traceroute output."""
+
+    _hyperglass_builtin: bool = PrivateAttr(True)
+    platforms: t.Sequence[str] = ("frr",)
+    directives: t.Sequence[str] = ("__hyperglass_frr_traceroute__",)
+    common: bool = False
+
+    def process(self, output: "OutputType", query: "Query") -> "OutputType":
+        """Process FRR traceroute output."""
+        # Extract target and source with fallbacks
+        target = str(query.query_target) if query.query_target else "unknown"
+        source = "unknown"
+
+        if hasattr(query, "device") and query.device:
+            source = getattr(query.device, "display_name", None) or getattr(
+                query.device, "name", "unknown"
+            )
+
+        # Logging
+        _log = log.bind(plugin="TraceroutePluginFrr")
+        _log.info(f"Processing Traceroute for {target} from {source}")
+
+        device = getattr(query, "device", None)
+        if device is not None:
+            if not getattr(device, "structured_output", False):
+                return output
+            try:
+                _params = use_state("params")
+            except Exception:
+                _params = None
+            if (
+                _params
+                and getattr(_params, "structured", None)
+                and getattr(_params.structured, "enable_for_traceroute", None) is False
+            ):
+                return output
+        else:
+            try:
+                params = use_state("params")
+            except Exception:
+                params = None
+            if not (params and getattr(params, "structured", None)):
+                return output
+            if getattr(params.structured, "enable_for_traceroute", None) is False:
+                return output
+
+        # Parse traceroute output
+        return parse_frr_traceroute(
+            output=output,
+            target=target,
+            source=source,
+        )

--- a/hyperglass/plugins/tests/test_bgp_route_mikrotik.py
+++ b/hyperglass/plugins/tests/test_bgp_route_mikrotik.py
@@ -1,0 +1,78 @@
+"""MikroTik structured BGP route parsing tests.
+
+The sample below is a trimmed, real `routing route print detail` capture from a
+RouterOS 7.20.6 device (CCR2216), reduced to one active and one filtered route.
+Long community lists are kept on a single line, matching what the device emits
+to the looking-glass SSH driver (no terminal-width wrapping).
+"""
+
+# flake8: noqa
+# Standard Library
+import typing as t
+
+# Third Party
+import pytest
+
+# Project
+from hyperglass.state import use_state
+from hyperglass.models.config.params import Params
+from hyperglass.models.data.bgp_route import BGPRouteTable
+from hyperglass.models.parsing.mikrotik import MikrotikBGPTable
+
+if t.TYPE_CHECKING:
+    from hyperglass.state import HyperglassState
+
+SAMPLE = """Flags: X - disabled, F - filtered, U - unreachable, A - active;
+c - connect, s - static, r - rip, b - bgp, n - bgp-net, o - ospf, i - isis, d - dhcp, v - vpn, m - modem, a - ldp-address, l - ldp-mapping, g - slaac, y - bgp-mpls-vpn, e - evpn;
+H - hw-offloaded; + - ecmp, B - blackhole
+ Ab   afi=ip contribution=active dst-address=1.0.0.0/24 routing-table=main pref-src=192.0.2.1 gateway=196.60.8.198
+       immediate-gw=196.60.8.198%[sfp28-01] distance=20 scope=40 target-scope=10 belongs-to="bgp-IP-196.60.8.198"
+       rpki=valid bgp.session=NAP-JHB-CloudFlare-v4-1 .as-path="13335" .communities=13335:10045 .large-communities=328964:2000:0,328964:2001:0 .local-pref=250 .med=0 .origin=igp
+
+ Fb   afi=ip contribution=filtered dst-address=5.101.88.0/24 routing-table=main pref-src=192.0.2.1 gateway=192.0.2.2
+       immediate-gw=192.0.2.2%[sfp28-10] distance=20 scope=40 target-scope=10 belongs-to="bgp-IP-192.0.2.2"
+       rpki=invalid bgp.session=TRANSIT-ANGOLA-v4-1 .as-path="37468,41095,51601,50113,207569" .communities=37468:14100,37468:2000 .med=0 .origin=incomplete
+"""
+
+
+@pytest.fixture
+def params() -> t.Dict[str, t.Any]:
+    return {}
+
+
+@pytest.fixture
+def state(*, params: t.Dict[str, t.Any]) -> t.Generator["HyperglassState", None, None]:
+    """Initialize Redis-backed state with params for BGPRoute validation."""
+    _state = use_state()
+    _params = Params(**params)
+    with _state.cache.pipeline() as pipeline:
+        pipeline.set("params", _params)
+    yield _state
+    _state.clear()
+
+
+def test_mikrotik_bgp_route(state):
+    table = MikrotikBGPTable.parse_text(SAMPLE).bgp_table()
+
+    assert isinstance(table, BGPRouteTable), "Parsed result is not a BGPRouteTable"
+    assert table.count == 2, f"Expected 2 routes, got {table.count}"
+
+    by_prefix = {r.prefix: r for r in table.routes}
+    assert set(by_prefix) == {"1.0.0.0/24", "5.101.88.0/24"}
+
+    # Active route (flag "A"): RPKI valid (state 1), single-ASN path.
+    active = by_prefix["1.0.0.0/24"]
+    assert active.active is True
+    assert active.filtered is False
+    assert active.as_path == [13335]
+    assert active.next_hop == "196.60.8.198"
+    assert "13335:10045" in active.communities
+    assert active.rpki_state == 1  # valid
+
+    # Filtered route (flag "F" => filtered per the RouterOS flags legend): RPKI
+    # invalid (state 0), multi-ASN path.
+    filtered = by_prefix["5.101.88.0/24"]
+    assert filtered.active is False
+    assert filtered.filtered is True, "F-flagged route should be marked filtered"
+    assert filtered.as_path == [37468, 41095, 51601, 50113, 207569]
+    assert filtered.rpki_state == 0  # invalid

--- a/hyperglass/plugins/tests/test_traceroute_mikrotik.py
+++ b/hyperglass/plugins/tests/test_traceroute_mikrotik.py
@@ -1,0 +1,153 @@
+"""MikroTik structured traceroute parsing tests.
+
+MikroTik's `/tool traceroute` redraws its table in place; the netmiko-based
+looking-glass driver captures the final accumulated table (one row per hop,
+SENT = total probes, with AVG/BEST/WORST filled in).
+
+Real RouterOS devices emit two distinct table layouts, both of which must parse:
+
+1. No index column, with a trailing STATUS column:
+       ADDRESS         LOSS SENT  LAST   AVG  BEST  WORST STD-DEV STATUS
+       198.51.100.7      0%    3  0.2ms  0.2  0.1   0.2   0
+
+2. Leading hop-index column ("#") and no STATUS column:
+       #  ADDRESS       LOSS  SENT  LAST     AVG   BEST  WORST  STD-DEV
+       0  192.0.2.1     0%       3  15.8ms   15.8  15.8  15.9         0
+
+The index column previously shifted every field and dropped all hops; the
+parser now detects and strips it. The fixtures below preserve the exact shape
+of real captures (hop counts, timeout rows, both layouts), but all addresses
+are RFC 5737 documentation ranges (192.0.2.0/24, 198.51.100.0/24,
+203.0.113.0/24) rather than real network data.
+
+The parser only populates fields it can read from the table (IP, loss, sent,
+RTTs). ASN/IXP/org enrichment is applied later by a separate plugin, so these
+parser tests assert only parser-produced fields.
+"""
+
+# flake8: noqa
+# Standard Library
+import typing as t
+
+# Third Party
+import pytest
+
+# Project
+from hyperglass.models.data.traceroute import TracerouteResult
+from hyperglass.plugins._builtin.trace_route_mikrotik import parse_mikrotik_traceroute
+
+# ---------------------------------------------------------------------------
+# Fixtures: (raw table, target, source, expected hops)
+# Each expected hop is (ip_address, loss_pct, best_rtt, worst_rtt).
+# Addresses are RFC 5737 documentation ranges (anonymized).
+# ---------------------------------------------------------------------------
+
+# Indexed layout ("#" column, no STATUS), including a timeout hop.
+INDEXED_5HOP = (
+    """ #  ADDRESS        LOSS  SENT  LAST     AVG   BEST  WORST  STD-DEV
+ 0  192.0.2.1      0%       3  15.8ms   15.8  15.8  15.9         0
+ 1                 100%     3  timeout
+ 2  198.51.100.7   0%       3  17.4ms   17.4  17.4  17.5         0
+ 3  198.51.100.8   0%       3  16.4ms   16.4  16.4  16.4         0
+ 4  203.0.113.8    0%       3  16.3ms   16.3  16.3  16.3         0
+""",
+    "203.0.113.8",
+    "router-a",
+    [
+        ("192.0.2.1", 0, 15.8, 15.9),
+        (None, 100, None, None),
+        ("198.51.100.7", 0, 17.4, 17.5),
+        ("198.51.100.8", 0, 16.4, 16.4),
+        ("203.0.113.8", 0, 16.3, 16.3),
+    ],
+)
+
+# Indexed layout, short 2-hop trace.
+INDEXED_2HOP = (
+    """ #  ADDRESS        LOSS  SENT  LAST   AVG  BEST  WORST  STD-DEV
+ 0  192.0.2.20     0%       3  4.4ms  7.6  0.7   17.7   7.3
+ 1  203.0.113.1    0%       3  0.8ms  0.8  0.8   0.8    0
+""",
+    "203.0.113.1",
+    "router-a",
+    [
+        ("192.0.2.20", 0, 0.7, 17.7),
+        ("203.0.113.1", 0, 0.8, 0.8),
+    ],
+)
+
+# Non-indexed layout with a trailing STATUS column.
+STATUS_COL_4HOP = (
+    """ADDRESS                          LOSS SENT    LAST     AVG    BEST   WORST STD-DEV STATUS
+192.0.2.10                         0%    3   0.2ms     0.2     0.1     0.2       0
+198.51.100.7                       0%    3   1.6ms     1.5     1.4     1.6     0.1
+198.51.100.8                       0%    3   0.5ms     0.5     0.5     0.5       0
+203.0.113.8                        0%    3     1ms       1       1       1       0
+""",
+    "203.0.113.8",
+    "router-b",
+    [
+        ("192.0.2.10", 0, 0.1, 0.2),
+        ("198.51.100.7", 0, 1.4, 1.6),
+        ("198.51.100.8", 0, 0.5, 0.5),
+        ("203.0.113.8", 0, 1.0, 1.0),
+    ],
+)
+
+STATUS_COL_5HOP = (
+    """ADDRESS                          LOSS SENT    LAST     AVG    BEST   WORST STD-DEV STATUS
+192.0.2.1                          0%    3   0.7ms     0.7     0.7     0.7       0
+192.0.2.10                         0%    3   0.9ms     0.9     0.8     0.9       0
+198.51.100.9                       0%    3   2.5ms     2.5     2.4     2.6     0.1
+198.51.100.10                      0%    3   2.3ms     2.2     2.1     2.3     0.1
+203.0.113.8                        0%    3   1.3ms     1.3     1.3     1.3       0
+""",
+    "203.0.113.8",
+    "router-c",
+    [
+        ("192.0.2.1", 0, 0.7, 0.7),
+        ("192.0.2.10", 0, 0.8, 0.9),
+        ("198.51.100.9", 0, 2.4, 2.6),
+        ("198.51.100.10", 0, 2.1, 2.3),
+        ("203.0.113.8", 0, 1.3, 1.3),
+    ],
+)
+
+CASES = {
+    "indexed-5hop": INDEXED_5HOP,
+    "indexed-2hop": INDEXED_2HOP,
+    "status-col-4hop": STATUS_COL_4HOP,
+    "status-col-5hop": STATUS_COL_5HOP,
+}
+
+
+@pytest.mark.parametrize("case", CASES.values(), ids=list(CASES.keys()))
+def test_mikrotik_traceroute(case: t.Tuple) -> None:
+    raw, target, source, expected = case
+    result = parse_mikrotik_traceroute(raw, target=target, source=source)
+
+    assert isinstance(result, TracerouteResult), "Expected a TracerouteResult"
+    assert len(result.hops) == len(expected), (
+        f"Expected {len(expected)} hops, got {len(result.hops)}"
+    )
+
+    for i, (hop, (ip, loss, best, worst)) in enumerate(zip(result.hops, expected), start=1):
+        assert hop.hop_number == i, f"Hop {i}: wrong hop_number {hop.hop_number}"
+        assert hop.ip_address == ip, f"Hop {i}: expected ip {ip!r}, got {hop.ip_address!r}"
+        assert hop.loss_pct == loss, f"Hop {i}: expected loss {loss}, got {hop.loss_pct}"
+        # BEST/WORST are preserved verbatim (AVG is a computed float and not
+        # safe for exact comparison).
+        assert hop.best_rtt == best, f"Hop {i}: expected best {best}, got {hop.best_rtt}"
+        assert hop.worst_rtt == worst, f"Hop {i}: expected worst {worst}, got {hop.worst_rtt}"
+
+    # The final hop is always the queried target.
+    assert result.hops[-1].ip_address == target
+
+
+def test_mikrotik_traceroute_timeout_hop() -> None:
+    """A 100%-loss (timeout) row yields a hop with no IP/RTT but loss recorded."""
+    result = parse_mikrotik_traceroute(*INDEXED_5HOP[:3])
+    timeout = result.hops[1]
+    assert timeout.ip_address is None
+    assert timeout.loss_pct == 100
+    assert timeout.last_rtt is None and timeout.avg_rtt is None


### PR DESCRIPTION
## Summary
Adds the shared MikroTik structured-output parsing base used by both structured BGP and structured traceroute:
- the MikroTik output parser (`models/parsing/mikrotik.py`),
- an enhanced garbage-output cleaner that handles `routing route print detail` and MikroTik's redraw-in-place traceroute table,
- a target-normalizer input plugin, and
- registration of `mikrotik_routeros` / `mikrotik_switchos` as structured-capable platforms.

Also hardens `Device.validate_structured_output`: it raised `ConfigError` with positional arguments (causing a `TypeError`) instead of the named placeholders the exception expects, so configuring `structured_output: true` on an unsupported platform now produces the intended `ConfigError`. Includes a parser unit test built from a real RouterOS 7.x capture.

---
**Stacked series (7/10).** Builds on `pr/ip-enrichment-service`.

### Also fixes (MikroTik output handling)
- Robust MikroTik output cleaning: strips interactive prompts and the flags legend, handles missing fields, and guards against non-string output.
- Deduplicates MikroTik traceroute output (the table is reprinted per probe cycle / redrawn in place).
- Populates the route **Originator** from the MikroTik `belongs-to` field.