### PR TITLE
fix(driver): run netmiko off the event loop and use send_command_timing

### DIFF
--- a/hyperglass/execution/drivers/ssh_netmiko.py
+++ b/hyperglass/execution/drivers/ssh_netmiko.py
@@ -29,7 +29,10 @@ netmiko_device_globals = {
     "mikrotik_switchos": {"global_cmd_verify": False},
 }
 
-netmiko_device_send_args = {}
+netmiko_device_send_args = {
+    "mikrotik_routeros": {"last_read": 5.0},
+    "mikrotik_switchos": {"last_read": 5.0},
+}
 
 
 class NetmikoConnection(SSHConnection):


### PR DESCRIPTION
## Summary

Fixes the netmiko SSH driver so blocking I/O no longer runs on the asyncio event loop, and switches to `send_command_timing` for more reliable output collection on devices with unpredictable prompts/pacing.

## Changes
- Run the synchronous netmiko calls in a worker thread instead of blocking the event loop.
- Use `send_command_timing` to avoid prompt-detection failures and premature truncation.

`hyperglass/execution/drivers/ssh_netmiko.py` — +26/−11.

## Notes
Standalone bug fix; independent of the structured-output PR series.
