### PR TITLE
fix(server): honor HYPERGLASS_WORKERS for web worker count

### DIFF
--- a/hyperglass/main.py
+++ b/hyperglass/main.py
@@ -28,7 +28,6 @@ if node_major < MIN_NODE_VERSION:
 
 
 # Local
-from .util import cpu_count
 from .state import use_state
 from .settings import Settings
 
@@ -151,13 +150,7 @@ def run(workers: int = None):
                 host=state.params.logging.syslog.host,
                 port=state.params.logging.syslog.port,
             )
-        _workers = workers
-
-        if workers is None:
-            if Settings.debug:
-                _workers = 1
-            else:
-                _workers = cpu_count(2)
+        _workers = workers if workers is not None else Settings.worker_count
 
         log.bind(
             version=__version__,

--- a/hyperglass/models/system.py
+++ b/hyperglass/models/system.py
@@ -50,6 +50,7 @@ class HyperglassSettings(BaseSettings):
     port: int = 8001
     ca_cert: t.Optional[FilePath] = None
     container: bool = False
+    workers: t.Optional[int] = None
 
     def __init__(self, **kwargs) -> None:
         """Create hyperglass Settings instance."""
@@ -136,8 +137,14 @@ class HyperglassSettings(BaseSettings):
         return "WARNING"
 
     @property
-    def workers(self: "HyperglassSettings") -> int:
-        """Get worker count, inferred from debug mode."""
+    def worker_count(self: "HyperglassSettings") -> int:
+        """Number of web-server workers.
+
+        Honors an explicit ``HYPERGLASS_WORKERS`` (the ``workers`` field, clamped
+        to at least 1) when set; otherwise 1 in debug mode, else 2x CPU cores.
+        """
+        if self.workers is not None:
+            return max(1, self.workers)
         if self.debug:
             return 1
         return cpu_count(2)

--- a/hyperglass/models/tests/test_system_workers.py
+++ b/hyperglass/models/tests/test_system_workers.py
@@ -1,0 +1,31 @@
+"""Tests for HyperglassSettings.worker_count."""
+
+# flake8: noqa
+# Project
+from hyperglass.util import cpu_count
+from hyperglass.models.system import HyperglassSettings
+
+
+def _settings(tmp_path, **kwargs):
+    return HyperglassSettings(app_path=tmp_path, **kwargs)
+
+
+def test_explicit_workers_honored(tmp_path):
+    assert _settings(tmp_path, debug=False, workers=4).worker_count == 4
+
+
+def test_workers_clamped_to_at_least_one(tmp_path):
+    assert _settings(tmp_path, debug=False, workers=0).worker_count == 1
+
+
+def test_debug_defaults_to_one(tmp_path):
+    assert _settings(tmp_path, debug=True).worker_count == 1
+
+
+def test_unset_non_debug_uses_cpu_default(tmp_path):
+    assert _settings(tmp_path, debug=False).worker_count == cpu_count(2)
+
+
+def test_explicit_workers_overrides_debug(tmp_path):
+    # An explicit worker count wins even in debug mode.
+    assert _settings(tmp_path, debug=True, workers=3).worker_count == 3


### PR DESCRIPTION
## Problem

`HyperglassSettings.workers` is a computed property hardcoded to `cpu_count(2)`
(2x logical cores) whenever `debug` is off, and `hyperglass/main.py` duplicates
that same inference inline. There is no settings field backing it, so the
`HYPERGLASS_WORKERS` environment variable is silently ignored.

On a 24-core host this starts **48** uvicorn workers regardless of intent — each
a full process holding the app plus its own Redis connections — with no
supported way to cap it. For a looking glass that is far more than needed.

## Fix

- Add a real `workers` settings field (`HYPERGLASS_WORKERS`), `Optional[int]`,
  default `None`.
- Replace the unused `workers` property with `worker_count`, which honors the
  field (clamped to `>= 1`) and otherwise keeps the previous behavior: `1` in
  debug mode, else `2x` CPU cores.
- `run()` now uses `Settings.worker_count` instead of duplicating the inference.

| `HYPERGLASS_WORKERS` | `debug` | workers |
| --- | --- | --- |
| unset | false | 2x cores (unchanged default) |
| unset | true | 1 (unchanged) |
| `4` | either | 4 |
| `0` | either | 1 (clamped) |

## Notes

- Self-contained: touches only `models/system.py` and `main.py`, independent of
  any other in-flight work, and applies cleanly to the current `main`.
- Backward compatible — the default is unchanged when `HYPERGLASS_WORKERS` is
  unset.
- Adds unit tests for `worker_count`.
