### PR TITLE
fix: shell-quote directive targets to prevent OS command injection

### DIFF
--- a/hyperglass/constants.py
+++ b/hyperglass/constants.py
@@ -87,3 +87,5 @@ LINUX_PLATFORMS = (
     "bird",
     "openbgpd",
 )
+
+SHELL_PLATFORMS = LINUX_PLATFORMS + ("tnsr",)

--- a/hyperglass/execution/drivers/_construct.py
+++ b/hyperglass/execution/drivers/_construct.py
@@ -9,12 +9,13 @@ hyperglass API modules.
 import re
 import json as _json
 import typing as t
+import shlex
 import ipaddress
 
 # Project
 from hyperglass.log import log
 from hyperglass.util import get_fmt_keys
-from hyperglass.constants import TRANSPORT_REST, TARGET_FORMAT_SPACE
+from hyperglass.constants import TRANSPORT_REST, TARGET_FORMAT_SPACE, SHELL_PLATFORMS
 from hyperglass.exceptions.public import InputInvalid
 from hyperglass.exceptions.private import ConfigError
 
@@ -110,7 +111,12 @@ class Construct:
         except ValueError:
             pass
 
-        return command.format(target=self.target, mask=mask, **attrs)
+        fmt = {"target": self.target, "mask": mask, **attrs}
+
+        if self.device.platform in SHELL_PLATFORMS:
+            return " ".join(shlex.quote(word.format(**fmt)) for word in shlex.split(command))
+
+        return command.format(**fmt)
 
     def queries(self):
         """Return queries for each enabled AFI."""

--- a/hyperglass/models/api/query.py
+++ b/hyperglass/models/api/query.py
@@ -23,7 +23,10 @@ from ..config.devices import Device
 
 
 QueryLocation = Annotated[str, StringConstraints(strict=True, min_length=1, strip_whitespace=True)]
-QueryTarget = Annotated[str, StringConstraints(min_length=1, strip_whitespace=True)]
+QueryTarget = Annotated[
+    str,
+    StringConstraints(min_length=1, strip_whitespace=True, pattern=r"^[^\x00-\x1f\x7f]+$"),
+]
 QueryType = Annotated[str, StringConstraints(strict=True, min_length=1, strip_whitespace=True)]
 
 


### PR DESCRIPTION
# Description

Directive command construction now shell-quotes the query target on platforms whose command string is executed by a POSIX shell, so an untrusted target can no longer break out of its intended argument.

For FRR/BIRD/OpenBGPD (`device_type="linux_ssh"`) and TNSR (`dataplane shell sudo vtysh -c`), `Construct.format()` no longer does a bare `str.format`. It splits the trusted template into words, fills the fields in each word, then `shlex.quote`s every word and rejoins:

```python
if self.device.platform in SHELL_PLATFORMS:
    return " ".join(shlex.quote(word.format(**fmt)) for word in shlex.split(command))
return command.format(**fmt)
```

Because the template is tokenized *before* the target is substituted, the target always lands inside a single argv word and can never introduce a new one — regardless of content. Legitimate regex syntax (`$`, `|`, `()`, `^$`) and prefixes are preserved, and the previously-unquoted OpenBGPD template is covered by the same path. Non-shell NOS platforms keep the plain `str.format` path, since their CLIs do not parse POSIX quoting.

Separately, `QueryTarget` now rejects ASCII control characters (`\x00–\x1f`, `\x7f`). This closes the newline-injection vector on the non-shell NOS platforms, where netmiko's `rstrip`-only `normalize_cmd` otherwise lets an embedded newline execute as a second CLI line. No legitimate BGP query target contains a control character.

There are **no directive-template changes** — the fix is entirely in the constructor and the query model, so a template can be edited freely without reintroducing the issue.

**Scope note on TNSR:** TNSR is included in `SHELL_PLATFORMS` because it shells out. The quoting produces one correctly-quoted POSIX shell line, which is right for the bash that `dataplane shell` reaches; the TNSR CLI parser in front of that bash has quoting semantics I have not verified against real firmware. FRR/BIRD/OpenBGPD go straight to bash and are unaffected. Happy to drop TNSR and track it separately if preferred.

# Related Issues

Fixes #383.

# Motivation and Context

The builtin directive templates for the shell-backed platforms interpolate the **unauthenticated** query target directly into a command string that a POSIX shell then executes, e.g. `vtysh -c "show bgp ipv4 unicast regexp {target}"`. Two things let it break out:

1. `Construct.format()` substituted the target with a bare `str.format()` — no shell escaping.
2. The default `condition="*"` rule compiles to `re.compile(".+").match()`, which is start-anchored and matches any non-empty string, so every input passes validation.

A `"` in the target closes the quote and a following `;` / `` ` `` / `$(...)` reaches the shell; OpenBGPD's template is unquoted, so a bare `;` injects directly. The response still returns the legitimate `show bgp` output, so the injection is not visible in the query result. The net effect is arbitrary command execution on the managed router from a single unauthenticated `POST /api/query`.

# Tests

- **Lint/format:** `ruff check` and `ruff format --check` pass on all changed files (matches the CI `rye lint` step); longest new line is 93 chars (limit 100).
- **Existing suite:** the change is a no-op for non-shell platforms, so `hyperglass/execution/drivers/tests/test_construct.py` (a Juniper case) is unaffected.
- **End-to-end:** against a full stack (Redis + FRRouting over SSH + a build with this change) on Linux / Python 3.12, the original payload plus quote / `$()` / backtick / `;` / `|` / `&` / newline bypass variants no longer execute anything on the router, while legitimate anchored (`_65000$`), empty-path (`^$`), and community (`65000:100`) queries still return `level=success`.
- **Template sweep:** every shipped shell-platform template (FRR/BIRD/OpenBGPD/TNSR) was run through the exact `format()` logic against that payload set to confirm no target can break out of its argument and that legitimate targets are preserved unchanged.
